### PR TITLE
Various proposed revisions

### DIFF
--- a/draft-reddy-add-enterprise-split-dns-08.txt
+++ b/draft-reddy-add-enterprise-split-dns-08.txt
@@ -261,8 +261,9 @@ Internet-Draft       Split-Horizon DNS Configuration        January 2022
    The client resolves the NS record using any resolution method of its
    choice (e.g. querying one of the network-provided resolvers,
    performing iterative resolution locally), and performs full DNSSEC
-   validation locally [RFC6698].  If the result is "Unsigned Zone",
-   clients SHOULD retry using the method in Section 3.1.1.
+   validation locally [RFC6698].  If the result is "Insecure" (Section 5
+   of [RFC4034]), clients SHOULD retry using the method in
+   Section 3.1.1.
 
 4.  An example of Split-Horizon DNS Configuration
 
@@ -273,7 +274,6 @@ Internet-Draft       Split-Horizon DNS Configuration        January 2022
 
    To add support for the mechanism described in this document, the
    network and endpoints first need to support [I-D.ietf-add-dnr] and
-   [RFC8801].  Then, for each site, the administrator would add DNS
 
 
 
@@ -282,6 +282,7 @@ Reddy, et al.             Expires July 17, 2022                 [Page 5]
 Internet-Draft       Split-Horizon DNS Configuration        January 2022
 
 
+   [RFC8801].  Then, for each site, the administrator would add DNS
    servers named "ns1.example.com" or "ns2.example.com" (the names
    published on the Internet).  Those names would be advertised to the
    endpoints as described in [I-D.ietf-add-dnr].
@@ -329,7 +330,6 @@ Internet-Draft       Split-Horizon DNS Configuration        January 2022
       information from [I-D.ietf-add-dnr] and [RFC8801] to resolve names
       within dnsZones.
 
-+---------+                 +---------------------+  +------------+ +---------+ +---------+
 
 
 
@@ -338,6 +338,7 @@ Reddy, et al.             Expires July 17, 2022                 [Page 6]
 Internet-Draft       Split-Horizon DNS Configuration        January 2022
 
 
++---------+                 +---------------------+  +------------+ +---------+ +---------+
 | client  |                 | Network             |  | Network    | | Router  | | public  |
 |         |                 | encrypted resolvr   |  | PvD server | |         | | resolvr |
 +---------+                 +---------------------+  +------------+ +---------+ +---------+
@@ -385,7 +386,6 @@ Internet-Draft       Split-Horizon DNS Configuration        January 2022
      |<--------------------------------------------------------------------------|
      | -------------------------------\         |         |          |           |
      |-| both DNR ADNs are authorized |         |         |          |           |
-     | ----------------------\--------|         |         |          |           |
 
 
 
@@ -394,6 +394,7 @@ Reddy, et al.             Expires July 17, 2022                 [Page 7]
 Internet-Draft       Split-Horizon DNS Configuration        January 2022
 
 
+     | ----------------------\--------|         |         |          |           |
      |-| finished validation |                  |         |          |           |
      | |---------------------|                  |         |          |           |
      |                                          |         |          |           |
@@ -440,8 +441,7 @@ Internet-Draft       Split-Horizon DNS Configuration        January 2022
 
    This specification does not alter DNSSEC validation behavior.  To
    ensure compatibility with validating clients, network operators MUST
-   ensure that names under the split horizon are correctly signed or
-   place them in an unsigned zone.
+
 
 
 
@@ -449,6 +449,9 @@ Reddy, et al.             Expires July 17, 2022                 [Page 8]
 
 Internet-Draft       Split-Horizon DNS Configuration        January 2022
 
+
+   ensure that names under the split horizon are correctly signed or
+   place them in an unsigned zone.
 
 7.  IANA Considerations
 
@@ -479,6 +482,11 @@ Internet-Draft       Split-Horizon DNS Configuration        January 2022
               Unique DNS Root", RFC 2826, DOI 10.17487/RFC2826, May
               2000, <https://www.rfc-editor.org/info/rfc2826>.
 
+   [RFC4034]  Arends, R., Austein, R., Larson, M., Massey, D., and S.
+              Rose, "Resource Records for the DNS Security Extensions",
+              RFC 4034, DOI 10.17487/RFC4034, March 2005,
+              <https://www.rfc-editor.org/info/rfc4034>.
+
    [RFC6698]  Hoffman, P. and J. Schlyter, "The DNS-Based Authentication
               of Named Entities (DANE) Transport Layer Security (TLS)
               Protocol: TLSA", RFC 6698, DOI 10.17487/RFC6698, August
@@ -487,14 +495,6 @@ Internet-Draft       Split-Horizon DNS Configuration        January 2022
    [RFC6761]  Cheshire, S. and M. Krochmal, "Special-Use Domain Names",
               RFC 6761, DOI 10.17487/RFC6761, February 2013,
               <https://www.rfc-editor.org/info/rfc6761>.
-
-   [RFC6762]  Cheshire, S. and M. Krochmal, "Multicast DNS", RFC 6762,
-              DOI 10.17487/RFC6762, February 2013,
-              <https://www.rfc-editor.org/info/rfc6762>.
-
-   [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
-              2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
-              May 2017, <https://www.rfc-editor.org/info/rfc8174>.
 
 
 
@@ -505,6 +505,14 @@ Reddy, et al.             Expires July 17, 2022                 [Page 9]
 
 Internet-Draft       Split-Horizon DNS Configuration        January 2022
 
+
+   [RFC6762]  Cheshire, S. and M. Krochmal, "Multicast DNS", RFC 6762,
+              DOI 10.17487/RFC6762, February 2013,
+              <https://www.rfc-editor.org/info/rfc6762>.
+
+   [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
+              2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
+              May 2017, <https://www.rfc-editor.org/info/rfc8174>.
 
    [RFC8310]  Dickinson, S., Gillmor, D., and T. Reddy, "Usage Profiles
               for DNS over TLS and DNS over DTLS", RFC 8310,
@@ -546,14 +554,6 @@ Internet-Draft       Split-Horizon DNS Configuration        January 2022
               Practices", draft-krishnaswamy-dnsop-dnssec-split-view-04
               (work in progress), March 2007.
 
-   [INS]      The Unicode Consortium, "Vodafone Foundation Instant
-              Schools for Sub-Saharan Africa",
-              <https://www.vodafone.com/about/vodafone-foundation/focus-
-              areas/instant-schools>.
-
-
-
-
 
 
 
@@ -561,6 +561,11 @@ Reddy, et al.             Expires July 17, 2022                [Page 10]
 
 Internet-Draft       Split-Horizon DNS Configuration        January 2022
 
+
+   [INS]      The Unicode Consortium, "Vodafone Foundation Instant
+              Schools for Sub-Saharan Africa",
+              <https://www.vodafone.com/about/vodafone-foundation/focus-
+              areas/instant-schools>.
 
    [private-relay]
               CA/B Forum, "How Apple's iCloud Private Relay supports
@@ -604,11 +609,6 @@ Internet-Draft       Split-Horizon DNS Configuration        January 2022
               (ACME)", RFC 8555, DOI 10.17487/RFC8555, March 2019,
               <https://www.rfc-editor.org/info/rfc8555>.
 
-   [RFC8598]  Pauly, T. and P. Wouters, "Split DNS Configuration for the
-              Internet Key Exchange Protocol Version 2 (IKEv2)",
-              RFC 8598, DOI 10.17487/RFC8598, May 2019,
-              <https://www.rfc-editor.org/info/rfc8598>.
-
 
 
 
@@ -617,6 +617,11 @@ Reddy, et al.             Expires July 17, 2022                [Page 11]
 
 Internet-Draft       Split-Horizon DNS Configuration        January 2022
 
+
+   [RFC8598]  Pauly, T. and P. Wouters, "Split DNS Configuration for the
+              Internet Key Exchange Protocol Version 2 (IKEv2)",
+              RFC 8598, DOI 10.17487/RFC8598, May 2019,
+              <https://www.rfc-editor.org/info/rfc8598>.
 
    [RFC8806]  Kumari, W. and P. Hoffman, "Running a Root Server Local to
               a Resolver", RFC 8806, DOI 10.17487/RFC8806, June 2020,
@@ -649,11 +654,6 @@ Authors' Addresses
    UK
 
    Email: kevin.smith@vodafone.com
-
-
-
-
-
 
 
 

--- a/draft-reddy-add-enterprise-split-dns-08.txt
+++ b/draft-reddy-add-enterprise-split-dns-08.txt
@@ -5,10 +5,10 @@
 ADD                                                             T. Reddy
 Internet-Draft                                                    Akamai
 Intended status: Standards Track                                 D. Wing
-Expires: July 13, 2022                                            Citrix
+Expires: July 17, 2022                                            Citrix
                                                                 K. Smith
                                                                 Vodafone
-                                                         January 9, 2022
+                                                        January 13, 2022
 
 
                     Split-Horizon DNS Configuration
@@ -16,13 +16,13 @@ Expires: July 13, 2022                                            Citrix
 
 Abstract
 
-   When split-horizon DNS is deployed by a network, certain domains are
-   only resolvable by querying the network-designated DNS server rather
-   than a public DNS server.  DNS clients which use DNS servers not
-   provided by the network need to route those DNS domain queries to the
-   network-designated DNS server.  This document informs DNS clients of
-   split-horizon DNS, their DNS domains, and is compatible with
-   encrypted DNS.
+   When split-horizon DNS is deployed by a network, certain domains can
+   be resolved authoritatively by the network-provided DNS resolver.
+   DNS clients that don't always use this resolver might wish to do so
+   for these domains.  This specification enables networks to inform DNS
+   clients about domains that are inside the split horizon DNS, and
+   describes how clients can confirm the local resolver's authority over
+   these domains.
 
 Status of This Memo
 
@@ -39,7 +39,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on July 13, 2022.
+   This Internet-Draft will expire on July 17, 2022.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Reddy, et al.             Expires July 13, 2022                 [Page 1]
+Reddy, et al.             Expires July 17, 2022                 [Page 1]
 
 Internet-Draft       Split-Horizon DNS Configuration        January 2022
 
@@ -68,65 +68,74 @@ Table of Contents
 
    1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
    2.  Terminology . . . . . . . . . . . . . . . . . . . . . . . . .   3
-     2.1.  Full Split Horizon  . . . . . . . . . . . . . . . . . . .   3
-     2.2.  Lame Delegation Split Horizon . . . . . . . . . . . . . .   4
-     2.3.  Domain Camping  . . . . . . . . . . . . . . . . . . . . .   5
-   3.  Overview for Full Split Horizon . . . . . . . . . . . . . . .   5
-   4.  Provisioning Domains dnsZones . . . . . . . . . . . . . . . .   6
-     4.1.  Authority over the Domains  . . . . . . . . . . . . . . .   6
-       4.1.1.  Authority based on a pre-configured public resolver .   7
-       4.1.2.  DNSSEC verification . . . . . . . . . . . . . . . . .   8
-       4.1.3.  Certificate verification  . . . . . . . . . . . . . .   9
-   5.  An example of Split-Horizon DNS Configuration . . . . . . . .  10
-   6.  Split DNS Configuration for IKEv2 . . . . . . . . . . . . . .  13
-   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  13
-   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  14
-   9.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  14
-   10. References  . . . . . . . . . . . . . . . . . . . . . . . . .  14
-     10.1.  Normative References . . . . . . . . . . . . . . . . . .  14
-     10.2.  Informative References . . . . . . . . . . . . . . . . .  15
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  16
+     2.1.  Authorized Split Horizon  . . . . . . . . . . . . . . . .   3
+     2.2.  Domain Camping  . . . . . . . . . . . . . . . . . . . . .   4
+   3.  Provisioning Domains dnsZones . . . . . . . . . . . . . . . .   4
+     3.1.  Confirming Authority over the Domains . . . . . . . . . .   5
+       3.1.1.  Confirmation using a pre-configured public resolver .   5
+       3.1.2.  Confirmation using DNSSEC . . . . . . . . . . . . . .   5
+   4.  An example of Split-Horizon DNS Configuration . . . . . . . .   5
+   5.  Split DNS Configuration for IKEv2 . . . . . . . . . . . . . .   8
+   6.  Security Considerations . . . . . . . . . . . . . . . . . . .   8
+   7.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   9
+   8.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .   9
+   9.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   9
+     9.1.  Normative References  . . . . . . . . . . . . . . . . . .   9
+     9.2.  Informative References  . . . . . . . . . . . . . . . . .  10
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  12
 
 1.  Introduction
 
-   Historically, an endpoint would utilize network-designated DNS
-   servers upon joining a network (e.g., DHCP OFFER, IPv6 Router
-   Advertisement).  While it has long been possible to configure
-   endpoints to ignore the network's suggestions and use a public DNS
-   server on the Internet, this was seldom used because some networks
-   block UDP/53 in order to enforce their own DNS policies.  Also, there
-   has been an increase in the availability of "public resolvers"
-   [RFC8499] which DNS clients may be pre-configured to use instead of
-   the default network resolver for a variety of reasons (e.g., offer a
-   good reachability, support an encrypted transport, provide a claimed
-   privacy policy, (lack of) filtering).  With the advent of DoT and
-   DoH, the endpoint is unable to properly resolve split-horizon DNS
-   domains which must query the network-designated DNS server.
+   To resolve a DNS query, there are three essential behaviors that an
+   implementation can apply: (1) answer from a local database, (2) query
+   the relevant authorities and their parents, or (3) ask a server to
+   query those authorities and return the final answer.  Implementations
+   that use these behaviors are called "authoritative nameservers",
+   "full resolvers", and "forwarders" (or "stub resolvers").  However,
+   an implementation can also implement a mixture of these behaviors,
+   depending on a local policy, for each query.  We term such an
+   implementation a "hybrid resolver".
 
-   This document specifies a mechanism to indicate which DNS zones are
-   used for split-horizon DNS.  DNS clients can discover and
+   Most DNS resolvers are hybrids of some kind.  For example, stub
+   resolvers frequently support a local "hosts file" that preempts query
+   forwarding, and most DNS forwarders and full resolvers can also serve
+   responses from a local zone file.  Other standardized hybrid
+   resolution behaviors include Local Root [RFC8806], mDNS [RFC6762],
+   and NXDOMAIN synthesis for .onion [RFC7686].
+
+   In many network environments, the network offers clients a DNS server
+   (e.g. in DHCP OFFER, IPv6 Router Advertisement).  Although this
+   server is formally specified as a recursive resolver (e.g.
 
 
 
-
-Reddy, et al.             Expires July 13, 2022                 [Page 2]
+Reddy, et al.             Expires July 17, 2022                 [Page 2]
 
 Internet-Draft       Split-Horizon DNS Configuration        January 2022
 
 
-   authenticate DNS servers provided by the network, for example using
-   the techniques proposed in [I-D.ietf-add-dnr] and [I-D.ietf-add-ddr].
+   Section 5.1 of [RFC6106]), some networks provide a hybrid resolver
+   instead.  If this resolver acts as an authoritative server for some
+   names, we say that the network has "split horizon DNS", because those
+   names resolve in this way only from inside the network.
 
-   The scope of the specification is full split-horizon (Section 2.1)
-   DNS names, which are not domains reserved for special use like
-   ".local".  Using these domains are difficult because bookmarks,
-   advertising, and human behavior would need to change so that the
-   special domains only work when connected to the correct network,
-   which is difficult for users to discern on most endpoints.
-   Furthermore, as special domains cannot obtain certificates from a
-   public CA, authenticated TLS connections to those servers are fraught
-   with (Trust on First Use) and certificate warnings, a longstanding
-   problem in the industry.
+   Network clients that use pure stub resolution, sending all queries to
+   the network-provided resolver, will always receive the split-horizon
+   results.  Conversely, clients that send all queries to a different
+   resolver or implement pure full resolution locally will never receive
+   them.  Clients with either pure resolution behavior are out of scope
+   for this specification.  Instead, this specification enables hybrid
+   clients to access split-horizon results from a network-provided
+   hybrid resolver, while using a different resolution method for some
+   or all other names.
+
+   To achieve the required security properties, clients must be able to
+   authenticate the DNS servers provided by the network, for example
+   using the techniques proposed in [I-D.ietf-add-dnr] and
+   [I-D.ietf-add-ddr], and prove that they are authorized to serve the
+   offered split-horizon names.  As a result, use of this specification
+   is limited to servers that support authenticated encryption and
+   split-horizon names that are properly rooted in the global DNS.
 
 2.  Terminology
 
@@ -142,98 +151,26 @@ Internet-Draft       Split-Horizon DNS Configuration        January 2022
    'Encrypted DNS' refers to a DNS protocol that provides an encrypted
    channel between a DNS client and server (e.g., DoT, DoH, or DoQ).
 
-   Two new terms, Full Split Horizon and Lame Delegation Split Horizon,
-   are defined as summarized in the following table.
+   The terms 'Authorized Split Horizon' and 'Domain Camping' are also
+   defined.
 
-+--------------------+----------------------+--------------------------+
-+ split horizon type +   query on Internet  | query on private network |
-+--------------------+----------------------+--------------------------+
-+ full               +  IP address <public> |   IP address <private>   |
-+--------------------+----------------------+--------------------------+
-+ lame delegation    +     no such host     |   IP address <private>   |
-+--------------------+----------------------+--------------------------+
+2.1.  Authorized Split Horizon
 
-   The term 'Domain Camping' is also defined.
-
-2.1.  Full Split Horizon
-
-   Full Split Horizon refers to a delegation on both the Internet-facing
-   DNS server and the internal-facing DNS server, where an A or AAAA
-   query results in a different answer.
+   A split horizon configuration for some name is considered
+   "authorized" if any parent of that name has given the local network
+   permission to serve its own responses for that name.  Such
+   authorizations generally extend to the entire subtree of names below
+   the authorization point.
 
 
 
 
-
-Reddy, et al.             Expires July 13, 2022                 [Page 3]
+Reddy, et al.             Expires July 17, 2022                 [Page 3]
 
 Internet-Draft       Split-Horizon DNS Configuration        January 2022
 
 
-   Example: When issued an "A" query for www.example.com, the Internet-
-   facing DNS server answers with 203.0.113.1 and internal-facing DNS
-   server answers with 192.0.2.1.
-
-   Benefits:
-
-   o  URLs resolve equally well on both public and internal networks,
-      but to different IP addresses, as desired by the DNS
-      administrator.
-
-   Complications:
-
-   o  Can cause cache confusion.
-
-   o  Clients need to query the appropriate DNS server to get the
-      appropriate answer.
-
-2.2.  Lame Delegation Split Horizon
-
-   Lame Delegation Split Horizon (or "lame split") refers to a lame
-   delegation on the Internet but a proper delegation on the internal
-   servers.
-
-   Example: On the public Internet, the zone internal.example.com is not
-   delegated at all, or alternatively, the delegation is purposefully
-   defective (e.g., NS record points to non-existent or non-responding
-   nameserver).  On the private network, that same zone
-   internal.example.com exists and FQDNs within it are resolvable, such
-   as www.internal.example.com which resolves to 192.0.2.2.
-
-      Note: Lame Delegation Split Horizon is not in scope for this
-      document.  It is only documented for completeness.
-      Implementations like iCloud Private Relay detect that the domain
-      being used is not a public Internet name and instructs the device
-      to access the domain directly over the local network
-      [private-relay].
-
-   Benefits:
-
-   o  If the client receives an error when querying the public server,
-      it can query the internal server.  While this exposes internal
-      host names to the public server, this eases client configuration
-      burden and can improve overall user satisfaction.
-
-   Complications:
-
-   o  In cases where the internal DNS server cannot be queried, URLs
-      referencing host names only resolvable by the internal DNS server
-
-
-
-Reddy, et al.             Expires July 13, 2022                 [Page 4]
-
-Internet-Draft       Split-Horizon DNS Configuration        January 2022
-
-
-      will not be resolvable and cause application errors.  These errors
-      can confuse users who see they are connected to the network, yet
-      cannot resolve a host name.
-
-   o  CA-signed certificates cannot be obtained for names that are not
-      resolvable on the Internet [cabforum].
-
-2.3.  Domain Camping
+2.2.  Domain Camping
 
    Domain Camping refers to operating a nameserver which claims to be
    authoritative for a zone, but actually isn't.  For example, a domain
@@ -243,69 +180,32 @@ Internet-Draft       Split-Horizon DNS Configuration        January 2022
    popular domain name providing the ability to monitor queries and
    modify answers for that domain.
 
-3.  Overview for Full Split Horizon
+   A common variation on domain camping is "NXDOMAIN camping", in which
+   a nameserver claims a zone that does not exist in the global DNS.
+   This is a form of domain camping because it seizes a portion of the
+   parent zone without permission.  The use of nonexistent TLDs for
+   local services is a form of NXDOMAIN camping on the root zone.
 
-   There are various DNS deployments outside of the global DNS,
-   including "split horizon" deployments and DNS usages on private (or
-   virtual private) networks.  In a Full Split Horizon, an authoritative
-   server gives different responses to queries from the Internet than
-   they do to network-designated DNS servers; while some deployments
-   differentiate internal queries from public queries by the source IP
-   address, the concerns in Section 3.1.1 of [RFC6950] relating to
-   trusting source IP addresses apply to such deployments.
+   Domain camping can be used as an attack vector to impersonate a
+   targeted domain.  Any form of domain camping likely violates the
+   IAB's guidance regarding "the Unique DNS Root" [RFC2826].
 
-   When the internal address space range is private [RFC1918], this
-   makes it both easier for the server to discriminate public from
-   private and harder for public entities to impersonate nodes in the
-   private network.  The use cases that motivate Full Split Horizon DNS
-   typically involves restricting access to internal services to the
-   devices attached and authenticated to the network.
-
-   A typical use case is an Enterprise network that requires one or more
-   DNS domains to be resolved via network-designated DNS servers.  An
-   Enterprise can run a different version of its global domain on its
-   internal network.  In that case, the client is instructed to send DNS
-   queries for the enterprise public domain (e.g., "example.com") to the
-   network-designated DNS servers.  A configuration for this deployment
-   scenario is referred to as a Full Split Horizon DNS configuration.
-   Another use case for Full Split Horizon DNS is Cellular and Fixed-
-   access networks (ISPs) typically offer value-added subscriber
-   services, including account status/controls, and free education
-   initiatives [INS].
-
-
-
-
-
-Reddy, et al.             Expires July 13, 2022                 [Page 5]
-
-Internet-Draft       Split-Horizon DNS Configuration        January 2022
-
-
-4.  Provisioning Domains dnsZones
-
-   As discussed in Section 3, a network can run a different version of
-   its global domain on its internal network, and require the use of
-   network-designated DNS servers to get resolved.
+3.  Provisioning Domains dnsZones
 
    Provisioning Domains (PvDs) are defined in [RFC7556] as sets of
    network configuration information that clients can use to access
    networks, including rules for DNS resolution and proxy configuration.
    The PvD Key dnsZones is defined in [RFC8801].  The PvD Key dnsZones
-   adds support for DNS domains for which the network claims authority,
-   and which are intended to be resolved using network-designated DNS
-   servers.  The global domains specified in the dnsZones key have a
-   different version in the internal network.  DNS resolution for other
-   domains remains unchanged.
+   notifies clients of names for which one of the network-provided
+   resolvers is authoritative.  Attempting to resolve these names via
+   another resolver might fail or return results that are not correct
+   for this network.
 
-   For each dnsZones entry, the client can use the network-designated
-   DNS servers to resolve the listed domains and its subdomains.  Other
-   domain names may be resolved using some other DNS servers that are
-   configured independently.  For example, if the dnsZones key specifies
-   "example.test", then "example.test", "www.example.test", and
-   "mail.eng.example.test" can be resolved using the network-designated
-   DNS resolver(s), but "otherexample.test" and "ple.test" can be
-   resolved using the system's public resolver(s).
+   Each dnsZones entry indicates a claim of authority over a domain and
+   its subdomains.  For example, if the dnsZones entry is
+   "example.test", this covers "example.test", "www.example.test", and
+   "mail.eng.example.test", but not "otherexample.test" or
+   "example.test.net".
 
    [RFC8801] defines a mechanism for discovering multiple Explicit PvDs
    on a single network and their Additional Information by means of an
@@ -317,272 +217,95 @@ Internet-Draft       Split-Horizon DNS Configuration        January 2022
    SHOULD include the "dnsZones" key to define the DNS domains for which
    the network claims authority.
 
-4.1.  Authority over the Domains
-
-   To comply with [RFC2826] the split-horizon DNS zone must either not
-   exist in the global DNS hierarchy or must be authoritatively
-   delegated to the split-horizon DNS server to answer.  The DNS root
-   zone (".") MUST be ignored if it appears in dnsZones.  Other generic
-   or global domains, such as Top-Level Domains (TLDs), similarly MUST
-   be ignored if they appear in dnsZones.
-
-   The client can use the mechanism described in [I-D.ietf-add-dnr] to
-   discover the network-designated resolvers.  To determine if the
-   network-designated encrypted resolvers are authoritative over the
 
 
 
 
-Reddy, et al.             Expires July 13, 2022                 [Page 6]
+Reddy, et al.             Expires July 17, 2022                 [Page 4]
 
 Internet-Draft       Split-Horizon DNS Configuration        January 2022
 
 
-   domains in dnsZones, the client can use any one of the mechanisms
-   discussed in Section 4.1.1, Section 4.1.2 and Section 4.1.3.
+3.1.  Confirming Authority over the Domains
 
-4.1.1.  Authority based on a pre-configured public resolver
+   To comply with [RFC2826], each dnsZones entry must be authorized in
+   the global DNS hierarchy.  To prevent domain camping, clients SHOULD
+   confirm this authorization before making use of the entry.
 
-   The client uses the following steps for each domain in dnsZones:
+   To enable confirmation, the client MUST discover and validate the
+   Authentication Domain Names (ADNs) of the network-designated
+   resolvers using a method such as DNR [I-D.ietf-add-dnr].  The client
+   MUST also perform an NS query for each dnsZones entry and confirm
+   that at least one of the ADNs appears in each NS RRSet.  This NS
+   query SHOULD be conducted in a manner that is not vulnerable to
+   tampering by the local network.  Suitable tamperproof resolution
+   strategies are described in Section 3.1.1 and Section 3.1.2.
 
-   1.  The client sends an NS query for the domain in dnsZones.  This
-       query must only be sent over encrypted DNS session to a public
-       resolver that is configured independently.  A DNSSEC-validating
-       client SHOULD apply the same validation policy to the NS query as
-       it does to other queries.  A client that does not validate DNSSEC
-       SHOULD apply the same policy (if any) to the NS query as it does
-       to other queries.  It is the choice of a client to either perform
-       full DNSSEC validation of answers or to trust the public resolver
-       to do DNSSEC validation and inspect the AD (Authentic Data) bit
-       in the returned message to determine whether an answer is
-       authentic or not.
+   Note that this confirmation of authority applies only to the specific
+   resolvers whose ADNs appear in each RRSet.  If a network offers
+   multiple encrypted resolvers via DNR, each dnsZone entry may be
+   authorized for a distinct subset of the resolvers.  If TLS
+   certificate validation fails for the ADN, that resolver MUST NOT be
+   considered authorized.
 
-   2.  The client checks that the NS RRset matches any one of the
-       Authentication Domain Names (ADNs) of the discovered network-
-       designated encrypted DNS resolvers.
+3.1.1.  Confirmation using a pre-configured public resolver
 
-       A.  If the match fails and no ADN of the discovered network-
-           designated encrypted DNS resolvers is a subdomain of NS
-           RRset, the client determines the network is not authoritative
-           for the indicated domain.  It might log an error, reject the
-           network entirely (because the network lied about its
-           authority over a domain) or other action.
+   The client sends an NS query for the domain in dnsZones to a pre-
+   configured resolver that is external to the network, over a secure
+   transport.  Clients SHOULD apply whatever acceptance rules they would
+   otherwise apply when using this resolver (e.g. checking the AD bit,
+   revalidating DNSSEC).
 
-       B.  If the match fails but any one of the ADNs of the discovered
-           network-designated encrypted DNS resolvers is a subdomain of
-           NS RRset, the client can then establish a TLS connection to
-           that network-designated resolver.  The client follows the
-           mechanism discussed in Section 8 of [RFC8310] to authenticate
-           the DNS server certificate using the ADN and checks if at
-           least one of the values in subjectAltName matches NS RRset.
-           If the server certificate validation and match succeeds, the
-           client can subsequently resolve the domains in that subtree
-           using the network-designated resolver.  If the server
-           certificate does not validate or match fails, the client can
-           proceed as discussed in step 2 (A).
+3.1.2.  Confirmation using DNSSEC
 
-       C.  If the match succeeds, the client can then establish a TLS
-           connection to that network-designated resolver.  The client
-           follows the mechanism discussed in Section 8 of [RFC8310] to
-           authenticate the DNS server certificate using the ADN.
+   The client resolves the NS record using any resolution method of its
+   choice (e.g. querying one of the network-provided resolvers,
+   performing iterative resolution locally), and performs full DNSSEC
+   validation locally [RFC6698].  If the result is "Unsigned Zone",
+   clients SHOULD retry using the method in Section 3.1.1.
 
+4.  An example of Split-Horizon DNS Configuration
 
-
-
-Reddy, et al.             Expires July 13, 2022                 [Page 7]
-
-Internet-Draft       Split-Horizon DNS Configuration        January 2022
-
-
-           +  If the server certificate does not validate and a secure
-              connection cannot be established to the network designated
-              resolver, the client can proceed as discussed in step 2
-              (A).
-
-           +  If the server certificate validation is successful and a
-              secure connection is established, the client can
-              subsequently resolve the domains in that subtree using the
-              network-designated resolver.
-
-   The mechanism has the following list of advantages in no particular
-   order:
-
-   o  As of the time of writing this specification OS and Browsers have
-      multiple pre-configured public resolvers and any one of the pre-
-      configured public resolver can be used.
-
-   The mechanism has the following list of caveats in no particular
-   order:
-
-   o  If the attached network blocks access to the public resolver, the
-      client will have to either use a different network or use the
-      network-designated resolver to resolve all domains.
-
-4.1.2.  DNSSEC verification
-
-   The proposed mechanism below requires a DNSSEC-validating stub
-   implementation (Section 2 of [RFC4033]).  The client can either send
-   the queries in recursive or iterative mode but performs signature
-   validation on its own.  Note that [RFC7901] defines an EDNS0
-   extension that allows a validating stub implementation to send a
-   single query, requesting a complete validation path along with the
-   regular query answer.  The reduction in DNSSEC queries potentially
-   lowers the latency and reduces the need to send multiple queries at
-   once.
-
-   Clients that validate the DNSSEC signatures can perform the following
-   steps for each domain in dnsZones:
-
-   1.  The client sends an NS query for the domain in dnsZones.  This
-       query is sent to the network-designated resolvers.  The response
-       records MUST be validated using DNSSEC as described in [RFC6698].
-
-   2.  The client checks that the NS RRset matches any one of the
-       Authentication Domain Names (ADNs) of the discovered network-
-       designated encrypted DNS resolvers.
-
-
-
-
-
-Reddy, et al.             Expires July 13, 2022                 [Page 8]
-
-Internet-Draft       Split-Horizon DNS Configuration        January 2022
-
-
-       A.  If the match fails, the client determines the network is not
-           authoritative for the indicated domain.  It might log an
-           error, reject the network entirely (because the network lied
-           about its authority over a domain) or other action.
-
-       B.  If the match succeeds, the client can then establish a TLS
-           connection to that network-designated resolver.  The client
-           follows the mechanism discussed in Section 8 of [RFC8310] to
-           authenticate the DNS server certificate using the ADN.
-
-           +  If the server certificate does not validate and a secure
-              connection cannot be established to the network designated
-              resolver, the client can proceed as discussed in step 2
-              (A).
-
-           +  If the server certificate validation is successful and a
-              secure connection is established, the client can
-              subsequently resolve the domains in that subtree using the
-              network-designated resolver.
-
-   The mechanism has the following list of advantages in no particular
-   order:
-
-   o  This approach does not require the client to access a public
-      resolver to prove the authority over the domains.
-
-   The mechanism has the following list of caveats in no particular
-   order:
-
-   o  The deployment of DNSSEC-validating stub implementation is limited
-      at the time of this writing specification.
-
-4.1.3.  Certificate verification
-
-   The client uses the mechanism described in [I-D.ietf-add-dnr] to
-   discover the ADNs of the network-designated resolvers.  The client
-   performs the following steps for each of the ADN:
-
-   1.  The client establishes a TLS connection to the ADN.  The client
-       follows the mechanism discussed in Section 8 of [RFC8310] to
-       authenticate the DNS server certificate using the ADN.  If the
-       server certificate does not validate, it might log an error,
-       reject the network entirely or other action.
-
-   2.  If the server certificate validation succeeds, the client checks
-       if the domains in dnsZones match the values in the
-       subjectAltName.  If the match succeeds, the client can
-
-
-
-
-Reddy, et al.             Expires July 13, 2022                 [Page 9]
-
-Internet-Draft       Split-Horizon DNS Configuration        January 2022
-
-
-       subsequently resolve the matched domains in that subtree using
-       the network-designated resolver.
-
-   The mechanism has the following list of advantages in no particular
-   order:
-
-   o  It does not require the client to access a public resolver or
-      requires the use of DNSSEC-validating stub implementation to prove
-      the authority over the domains.
-
-   The mechanism has the following list of caveats in no particular
-   order:
-
-   o  It requires the use of certificates with multiple dNSName
-      identifiers which are supported by both CAs and ACME protocol
-      [RFC8555].
-
-5.  An example of Split-Horizon DNS Configuration
-
-   In a network the apex domain name is "example.com", which runs a
+   Consider an organization that operates "example.com", and runs a
    different version of its global domain on its internal network.
    Today, on the Internet it publishes two NS records, "ns1.example.com"
    and "ns2.example.com".
 
    To add support for the mechanism described in this document, the
    network and endpoints first need to support [I-D.ietf-add-dnr] and
-   [RFC8801].  Then, for each site the administrator would add DNS
-   server names which end in "ns1.example.com" or "ns2.example.com" (the
-   names published on the Internet).  Also on its internal network, it
-   uses a geographic naming scheme for its internal nameservers with a
-   "service dot location" naming scheme.  Assuming its two geographies
-   are "us" and "uk".  So the UK site would add "ns1.uk.ns1.example.com"
-   and "ns2.uk.ns2.example.com".  Note that these names can be added in
-   addition to more traditional names that might already exist for those
-   DNS servers (e.g., the common "service dot location" such as
-   "ns1.uk.example.com").  All of those names would be advertised to the
-   endpoints as described in [I-D.ietf-add-dnr].
-
-   The endpoints compliant with this specification can then determine
-   the network's internal nameservers are owned and managed by the same
-   entity that has published the NS records on the Internet, as
-   described in the following paragraphs:
-
-   Continuing with the UK site as the example, the endpoint will join
-   the network, obtain an IPv6 address, and using [I-D.ietf-add-dnr]
-   will discover the resolvers "ns1.uk.ns1.example.com" and
-   "ns2.uk.ns2.example.com" and their IP addresses.  Using [RFC8801]
+   [RFC8801].  Then, for each site, the administrator would add DNS
 
 
 
-
-Reddy, et al.             Expires July 13, 2022                [Page 10]
+Reddy, et al.             Expires July 17, 2022                 [Page 5]
 
 Internet-Draft       Split-Horizon DNS Configuration        January 2022
 
 
-   (which utilizes IPv6 Router Advertisments), the endpoint will also
-   discover the PvD FQDN is "pvd.uk.example.com".
+   servers named "ns1.example.com" or "ns2.example.com" (the names
+   published on the Internet).  Those names would be advertised to the
+   endpoints as described in [I-D.ietf-add-dnr].
 
-   Continuing with the UK site as the example, the endpoint performs the
-   following steps corresponding with the call flow diagram numbers:
+   The endpoints compliant with this specification can then determine
+   the network's internal nameservers are owned and managed by the same
+   entity that has published the NS records on the Internet as shown in
+   Figure 1:
 
-   Steps 1-2:  The client joins the network, obtain an IP address, and
-      using [I-D.ietf-add-dnr] will discover the resolvers
-      "ns1.uk.ns1.example.com" and "ns2.uk.ns1.example.com" and their IP
-      addresses.  Using [RFC8801], the endpoint will also discover the
-      PvD FQDN is "pvd.uk.example.com".
+   Steps 1-2:  The client joins the network, obtains an IP address, and
+      discovers the resolvers "ns1.example.com" and "ns2.example.com"
+      and their IP addresses using DNR [I-D.ietf-add-dnr].  Using
+      [RFC8801], the client also discovers the PvD FQDN is
+      "pvd.example.com".
 
    Steps 3-7:  The client establishes an encrypted DNS connection with
-      "ns1.uk.ns1.example.com", validates its TLS certificate, and
-      queries it for "pvd.uk.example.com" to retrieve the PvD JSON
-      object.  Note that [RFC8801] in Section 4.1 mandates the PvD FQDN
-      MUST be resolved using the DNS servers indicated by the associated
-      PvD.  The PvD contains:
+      "ns1.example.com", validates its TLS certificate, and queries it
+      for "pvd.example.com" to retrieve the PvD JSON object.  Note that
+      [RFC8801] in Section 4.1 mandates the PvD FQDN MUST be resolved
+      using the DNS servers indicated by the associated PvD.  The PvD
+      contains:
 
     {
-       "identifier": "pvd.uk.example.com",
+       "identifier": "pvd.example.com",
        "expires": "2020-05-23T06:00:00Z",
        "prefixes": ["2001:db8:1::/48", "2001:db8:4::/48"],
        "dnsZones:": ["example.com"]
@@ -596,7 +319,7 @@ Internet-Draft       Split-Horizon DNS Configuration        January 2022
       domains in dnsZones.  The NS lookup for "example.com" will return
       "ns1.example.com" and "ns2.example.com".
 
-   Step 10:  As the network-provided nameservers are subdomains of those
+   Step 10:  As the network-provided nameservers are the same as the
       names retrieved from the public resolver and the network-
       designated resolver's certificate includes at least one of the
       names retrieved from the public resolver, the client has finished
@@ -606,92 +329,88 @@ Internet-Draft       Split-Horizon DNS Configuration        January 2022
       information from [I-D.ietf-add-dnr] and [RFC8801] to resolve names
       within dnsZones.
 
-   Figure 1 is a simple call flow diagram of the example discussed
-   above.
-
-+---------+                    +---------------------+  +------------+ +---------+ +---------+
++---------+                 +---------------------+  +------------+ +---------+ +---------+
 
 
 
-Reddy, et al.             Expires July 13, 2022                [Page 11]
+Reddy, et al.             Expires July 17, 2022                 [Page 6]
 
 Internet-Draft       Split-Horizon DNS Configuration        January 2022
 
 
-| client  |                    | Network             |  | Network    | | Router  | | public  |
-|         |                    | encrypted resolvr   |  | PvD server | |         | | resolvr |
-+---------+                    +---------------------+  +------------+ +---------+ +---------+
-     |                                             |         |          |           |
-     | Router Solicitation (1)                     |         |          |           |
-     |----------------------------------------------------------------->|           |
-     |                                             |         |          |           |
-     |       Router Advertisement with DNR hostnames & PvD FQDN (2)     |           |
-     |<----------------------------------=------------------------------|           |
-     | -------------------------------------\      |         |          |           |
-     |-| now knows DNR hostnames & PvD FQDN |      |         |          |           |
-     | |------------------------------------|      |         |          |           |
-     |                                             |         |          |           |
-     | TLS connection to ns1.uk.ns1.example.com (3)|         |          |           |
-     |----------------------------------------- -->|         |          |           |
-     | ---------------------------\                |         |          |           |
-     |-| validate TLS certificate |                |         |          |           |
-     | |--------------------------|                |         |          |           |
-     |                                             |         |          |           |
-     | resolve pvd.uk.example.com  (4)             |         |          |           |
-     |-------------------------------------------->|         |          |           |
-     |                                             |         |          |           |
-     |                         AAAA records (5)    |         |          |           |
-     |<--------------------------------------------|         |          |           |
-     |                                             |         |          |           |
-     | https://pvd.uk.example.com/.well-known/pvd (6)        |          |           |
-     |------------------------------------------------------>|          |           |
-     |                                             |         |          |           |
-     |       200 OK (JSON Additional Information) (7)        |          |           |
-     |<------------------------------------------------------|          |           |
-     | -----------------------\                    |         |          |           |
-     |-| dnsZones=example.com |                    |         |          |           |
-     | |----------------------|                    |         |          |           |
-     |                                             |         |          |           |
-     | TLS connection                              |         |          |           |
-     |----------------------------------------------------------------------------->|
-     | ---------------------------\                |         |          |           |
-     |-| validate TLS certificate |                |         |          |           |
-     | |--------------------------|                |         |          |           |
-     |                                             |         |          |           |
-     | NS? example.com  (8)                        |         |          |           |
-     |----------------------------------------------------------------------------->|
-     |                                             |         |          |           |
-     |                               NS=ns1.example.com, ns2.example.com (9)        |
-     |<-----------------------------------------------------------------------------|
-     | -------------------------------\            |         |          |           |
-     |-| ns1.uk.ns1.example.com is    |            |         |          |           |
-     | | subdomain of ns1.example.com |            |         |          |           |
+| client  |                 | Network             |  | Network    | | Router  | | public  |
+|         |                 | encrypted resolvr   |  | PvD server | |         | | resolvr |
++---------+                 +---------------------+  +------------+ +---------+ +---------+
+     |                                          |         |          |           |
+     | Router Solicitation (1)                  |         |          |           |
+     |-------------------------------------------------------------->|           |
+     |                                          |         |          |           |
+     |     Router Advertisement with DNR hostnames & PvD FQDN (2)    |           |
+     |<--------------------------------------------------------------|           |
+     | -------------------------------------\   |         |          |           |
+     |-| now knows DNR hostnames & PvD FQDN |   |         |          |           |
+     | |------------------------------------|   |         |          |           |
+     |                                          |         |          |           |
+     | TLS connection to ns1.example.com (3)    |         |          |           |
+     |----------------------------------------->|         |          |           |
+     | ---------------------------\             |         |          |           |
+     |-| validate TLS certificate |             |         |          |           |
+     | |--------------------------|             |         |          |           |
+     |                                          |         |          |           |
+     | resolve pvd.example.com  (4)             |         |          |           |
+     |----------------------------------------->|         |          |           |
+     |                                          |         |          |           |
+     |                      AAAA records (5)    |         |          |           |
+     |<-----------------------------------------|         |          |           |
+     |                                          |         |          |           |
+     | https://pvd.example.com/.well-known/pvd (6)        |          |           |
+     |--------------------------------------------------->|          |           |
+     |                                          |         |          |           |
+     |      200 OK (JSON Additional Information) (7)      |          |           |
+     |<---------------------------------------------------|          |           |
+     | -----------------------\                 |         |          |           |
+     |-| dnsZones=example.com |                 |         |          |           |
+     | |----------------------|                 |         |          |           |
+     |                                          |         |          |           |
+     | TLS connection                           |         |          |           |
+     |-------------------------------------------------------------------------->|
+     | ---------------------------\             |         |          |           |
+     |-| validate TLS certificate |             |         |          |           |
+     | |--------------------------|             |         |          |           |
+     |                                          |         |          |           |
+     | NS? example.com  (8)                     |         |          |           |
+     |-------------------------------------------------------------------------->|
+     |                                          |         |          |           |
+     |                            NS=ns1.example.com, ns2.example.com (9)        |
+     |<--------------------------------------------------------------------------|
+     | -------------------------------\         |         |          |           |
+     |-| both DNR ADNs are authorized |         |         |          |           |
+     | ----------------------\--------|         |         |          |           |
 
 
 
-Reddy, et al.             Expires July 13, 2022                [Page 12]
+Reddy, et al.             Expires July 17, 2022                 [Page 7]
 
 Internet-Draft       Split-Horizon DNS Configuration        January 2022
 
 
-     | ----------------------\--------|            |         |          |           |
-     |-| finished validation |                     |         |          |           |
-     | |---------------------|                     |         |          |           |
-     |                                             |         |          |           |
-     |  use network-designated resolver            |         |          |           |
-     |  for example.com (10)                       |         |          |           |
-     |-------------------------------------------->|         |          |           |
-     |                                             |         |          |           |
+     |-| finished validation |                  |         |          |           |
+     | |---------------------|                  |         |          |           |
+     |                                          |         |          |           |
+     |  use network-designated resolver         |         |          |           |
+     |  for example.com (10)                    |         |          |           |
+     |----------------------------------------->|         |          |           |
+     |                                          |         |          |           |
 
           Figure 1: An Example of Split-Horizon DNS Configuration
 
-6.  Split DNS Configuration for IKEv2
+5.  Split DNS Configuration for IKEv2
 
    The split-tunnel Virtual Private Network (VPN) configuration allows
    the endpoint to access resources that reside in the VPN [RFC8598] via
    the tunnel; other traffic not destined to the VPN does not traverse
-   the tunnel.  In contrast, a non-split- tunnel VPN configuration
-   causes all traffic to traverse the tunnel into the VPN.
+   the tunnel.  In contrast, a non-split-tunnel VPN configuration causes
+   all traffic to traverse the tunnel into the VPN.
 
    When the VPN tunnel is IPsec, the encrypted DNS resolver hosted by
    the VPN service provider can be securely discovered by the endpoint
@@ -702,53 +421,49 @@ Internet-Draft       Split-Horizon DNS Configuration        January 2022
    For non-split-tunnel VPN configurations, the endpoint uses the
    discovered encrypted DNS server to resolve both global and private
    domain names.  For split-tunnel VPN configurations, the IKE client
-   can use any one of the mechanisms discussed in Section 4.1 to
-   determine if the VPN service provider is authoritative over the Full
-   Split Horizon DNS domains.
+   can use any one of the mechanisms discussed in Section 3.1 to
+   determine if the VPN service provider is authoritative over the Split
+   Horizon DNS domains.
 
    Other VPN tunnel types have similar configuration capabilities, not
    detailed here.
 
-7.  Security Considerations
+6.  Security Considerations
 
    The content of dnsZones may be passed to another (DNS) program for
    processing.  As with any network input, the content SHOULD be
    considered untrusted and handled accordingly.  The client must
-   perform the mechanisms discussed in Section 4.1 to determine if the
+   perform the mechanisms discussed in Section 3.1 to determine if the
    network-designated encrypted resolvers are authoritative over the
-   domains in dnsZones.  If not, the client can take appropriate action
-   like disconnecting from the network.
+   domains in dnsZones.  If they are not, the client SHOULD ignore those
+   dnsZones.
 
-   In order to deploy DNSSEC operationally for split-horizon domains,
-   the first three schemes described in
-   [I-D.krishnaswamy-dnsop-dnssec-split-view] can be used but not the
+   This specification does not alter DNSSEC validation behavior.  To
+   ensure compatibility with validating clients, network operators MUST
+   ensure that names under the split horizon are correctly signed or
+   place them in an unsigned zone.
 
 
 
-Reddy, et al.             Expires July 13, 2022                [Page 13]
+Reddy, et al.             Expires July 17, 2022                 [Page 8]
 
 Internet-Draft       Split-Horizon DNS Configuration        January 2022
 
 
-   one discussed in Section 4.1.4.  Alternatively, after validating the
-   network authority over the dnsZones domains Section 4.1, a DNSSEC-
-   validating client can reconfigure its stub resolver to disable DNSSEC
-   validation for the domains in dnsZones.
+7.  IANA Considerations
 
-8.  IANA Considerations
+   This document has no IANA actions.
 
-   This document has no IANA actions..
-
-9.  Acknowledgements
+8.  Acknowledgements
 
    Thanks to Mohamed Boucadair, Jim Reid, Ben Schwartz, Tommy Pauly,
    Paul Vixie, Paul Wouters and Vinny Parla for the discussion and
    comments.  The authors would like to give special thanks to Ben
    Schwartz for his help.
 
-10.  References
+9.  References
 
-10.1.  Normative References
+9.1.  Normative References
 
    [RFC1918]  Rekhter, Y., Moskowitz, B., Karrenberg, D., de Groot, G.,
               and E. Lear, "Address Allocation for Private Internets",
@@ -777,18 +492,19 @@ Internet-Draft       Split-Horizon DNS Configuration        January 2022
               DOI 10.17487/RFC6762, February 2013,
               <https://www.rfc-editor.org/info/rfc6762>.
 
-
-
-
-
-Reddy, et al.             Expires July 13, 2022                [Page 14]
-
-Internet-Draft       Split-Horizon DNS Configuration        January 2022
-
-
    [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
               2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
               May 2017, <https://www.rfc-editor.org/info/rfc8174>.
+
+
+
+
+
+
+Reddy, et al.             Expires July 17, 2022                 [Page 9]
+
+Internet-Draft       Split-Horizon DNS Configuration        January 2022
+
 
    [RFC8310]  Dickinson, S., Gillmor, D., and T. Reddy, "Usage Profiles
               for DNS over TLS and DNS over DTLS", RFC 8310,
@@ -800,7 +516,7 @@ Internet-Draft       Split-Horizon DNS Configuration        January 2022
               RFC 8801, DOI 10.17487/RFC8801, July 2020,
               <https://www.rfc-editor.org/info/rfc8801>.
 
-10.2.  Informative References
+9.2.  Informative References
 
    [cabforum]
               CA/B Forum, "Internal Server Names and IP Address
@@ -837,7 +553,11 @@ Internet-Draft       Split-Horizon DNS Configuration        January 2022
 
 
 
-Reddy, et al.             Expires July 13, 2022                [Page 15]
+
+
+
+
+Reddy, et al.             Expires July 17, 2022                [Page 10]
 
 Internet-Draft       Split-Horizon DNS Configuration        January 2022
 
@@ -853,6 +573,11 @@ Internet-Draft       Split-Horizon DNS Configuration        January 2022
               RFC 4033, DOI 10.17487/RFC4033, March 2005,
               <https://www.rfc-editor.org/info/rfc4033>.
 
+   [RFC6106]  Jeong, J., Park, S., Beloeil, L., and S. Madanapalli,
+              "IPv6 Router Advertisement Options for DNS Configuration",
+              RFC 6106, DOI 10.17487/RFC6106, November 2010,
+              <https://www.rfc-editor.org/info/rfc6106>.
+
    [RFC6950]  Peterson, J., Kolkman, O., Tschofenig, H., and B. Aboba,
               "Architectural Considerations on Application Features in
               the DNS", RFC 6950, DOI 10.17487/RFC6950, October 2013,
@@ -861,6 +586,10 @@ Internet-Draft       Split-Horizon DNS Configuration        January 2022
    [RFC7556]  Anipko, D., Ed., "Multiple Provisioning Domain
               Architecture", RFC 7556, DOI 10.17487/RFC7556, June 2015,
               <https://www.rfc-editor.org/info/rfc7556>.
+
+   [RFC7686]  Appelbaum, J. and A. Muffett, "The ".onion" Special-Use
+              Domain Name", RFC 7686, DOI 10.17487/RFC7686, October
+              2015, <https://www.rfc-editor.org/info/rfc7686>.
 
    [RFC7901]  Wouters, P., "CHAIN Query Requests in DNS", RFC 7901,
               DOI 10.17487/RFC7901, June 2016,
@@ -880,6 +609,19 @@ Internet-Draft       Split-Horizon DNS Configuration        January 2022
               RFC 8598, DOI 10.17487/RFC8598, May 2019,
               <https://www.rfc-editor.org/info/rfc8598>.
 
+
+
+
+
+Reddy, et al.             Expires July 17, 2022                [Page 11]
+
+Internet-Draft       Split-Horizon DNS Configuration        January 2022
+
+
+   [RFC8806]  Kumari, W. and P. Hoffman, "Running a Root Server Local to
+              a Resolver", RFC 8806, DOI 10.17487/RFC8806, June 2020,
+              <https://www.rfc-editor.org/info/rfc8806>.
+
 Authors' Addresses
 
    Tirumaleswar Reddy
@@ -889,13 +631,6 @@ Authors' Addresses
    India
 
    Email: kondtir@gmail.com
-
-
-
-
-Reddy, et al.             Expires July 13, 2022                [Page 16]
-
-Internet-Draft       Split-Horizon DNS Configuration        January 2022
 
 
    Dan Wing
@@ -934,19 +669,4 @@ Internet-Draft       Split-Horizon DNS Configuration        January 2022
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Reddy, et al.             Expires July 13, 2022                [Page 17]
+Reddy, et al.             Expires July 17, 2022                [Page 12]

--- a/draft-reddy-add-enterprise-split-dns-08.txt
+++ b/draft-reddy-add-enterprise-split-dns-08.txt
@@ -5,10 +5,10 @@
 ADD                                                             T. Reddy
 Internet-Draft                                                    Akamai
 Intended status: Standards Track                                 D. Wing
-Expires: July 17, 2022                                            Citrix
+Expires: July 18, 2022                                            Citrix
                                                                 K. Smith
                                                                 Vodafone
-                                                        January 13, 2022
+                                                        January 14, 2022
 
 
                     Split-Horizon DNS Configuration
@@ -39,7 +39,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on July 17, 2022.
+   This Internet-Draft will expire on July 18, 2022.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Reddy, et al.             Expires July 17, 2022                 [Page 1]
+Reddy, et al.             Expires July 18, 2022                 [Page 1]
 
 Internet-Draft       Split-Horizon DNS Configuration        January 2022
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Reddy, et al.             Expires July 17, 2022                 [Page 2]
+Reddy, et al.             Expires July 18, 2022                 [Page 2]
 
 Internet-Draft       Split-Horizon DNS Configuration        January 2022
 
@@ -165,7 +165,7 @@ Internet-Draft       Split-Horizon DNS Configuration        January 2022
 
 
 
-Reddy, et al.             Expires July 17, 2022                 [Page 3]
+Reddy, et al.             Expires July 18, 2022                 [Page 3]
 
 Internet-Draft       Split-Horizon DNS Configuration        January 2022
 
@@ -186,9 +186,8 @@ Internet-Draft       Split-Horizon DNS Configuration        January 2022
    parent zone without permission.  The use of nonexistent TLDs for
    local services is a form of NXDOMAIN camping on the root zone.
 
-   Domain camping can be used as an attack vector to impersonate a
-   targeted domain.  Any form of domain camping likely violates the
-   IAB's guidance regarding "the Unique DNS Root" [RFC2826].
+   Any form of domain camping likely violates the IAB's guidance
+   regarding "the Unique DNS Root" [RFC2826].
 
 3.  Provisioning Domains dnsZones
 
@@ -221,7 +220,8 @@ Internet-Draft       Split-Horizon DNS Configuration        January 2022
 
 
 
-Reddy, et al.             Expires July 17, 2022                 [Page 4]
+
+Reddy, et al.             Expires July 18, 2022                 [Page 4]
 
 Internet-Draft       Split-Horizon DNS Configuration        January 2022
 
@@ -241,12 +241,10 @@ Internet-Draft       Split-Horizon DNS Configuration        January 2022
    tampering by the local network.  Suitable tamperproof resolution
    strategies are described in Section 3.1.1 and Section 3.1.2.
 
-   Note that this confirmation of authority applies only to the specific
-   resolvers whose ADNs appear in each RRSet.  If a network offers
-   multiple encrypted resolvers via DNR, each dnsZone entry may be
-   authorized for a distinct subset of the resolvers.  If TLS
-   certificate validation fails for the ADN, that resolver MUST NOT be
-   considered authorized.
+   Note that each dnsZones entry is authorized only for the specific
+   resolvers whose ADNs appear in its NS RRSet.  If a network offers
+   multiple encrypted resolvers via DNR, each dnsZones entry may be
+   authorized for a distinct subset of the network-provided resolvers.
 
 3.1.1.  Confirmation using a pre-configured public resolver
 
@@ -262,8 +260,8 @@ Internet-Draft       Split-Horizon DNS Configuration        January 2022
    choice (e.g. querying one of the network-provided resolvers,
    performing iterative resolution locally), and performs full DNSSEC
    validation locally [RFC6698].  If the result is "Insecure" (Section 5
-   of [RFC4034]), clients SHOULD retry using the method in
-   Section 3.1.1.
+   of [RFC4034]), the client SHOULD retry using a different method, such
+   as the one in Section 3.1.1.
 
 4.  An example of Split-Horizon DNS Configuration
 
@@ -274,16 +272,16 @@ Internet-Draft       Split-Horizon DNS Configuration        January 2022
 
    To add support for the mechanism described in this document, the
    network and endpoints first need to support [I-D.ietf-add-dnr] and
+   [RFC8801].  Then, for each site, the administrator would add DNS
+   servers named "ns1.example.com" or "ns2.example.com" (the names
 
 
 
-Reddy, et al.             Expires July 17, 2022                 [Page 5]
+Reddy, et al.             Expires July 18, 2022                 [Page 5]
 
 Internet-Draft       Split-Horizon DNS Configuration        January 2022
 
 
-   [RFC8801].  Then, for each site, the administrator would add DNS
-   servers named "ns1.example.com" or "ns2.example.com" (the names
    published on the Internet).  Those names would be advertised to the
    endpoints as described in [I-D.ietf-add-dnr].
 
@@ -330,16 +328,16 @@ Internet-Draft       Split-Horizon DNS Configuration        January 2022
       information from [I-D.ietf-add-dnr] and [RFC8801] to resolve names
       within dnsZones.
 
++---------+                 +---------------------+  +------------+ +---------+ +---------+
+| client  |                 | Network             |  | Network    | | Router  | | public  |
 
 
 
-Reddy, et al.             Expires July 17, 2022                 [Page 6]
+Reddy, et al.             Expires July 18, 2022                 [Page 6]
 
 Internet-Draft       Split-Horizon DNS Configuration        January 2022
 
 
-+---------+                 +---------------------+  +------------+ +---------+ +---------+
-| client  |                 | Network             |  | Network    | | Router  | | public  |
 |         |                 | encrypted resolvr   |  | PvD server | |         | | resolvr |
 +---------+                 +---------------------+  +------------+ +---------+ +---------+
      |                                          |         |          |           |
@@ -386,16 +384,16 @@ Internet-Draft       Split-Horizon DNS Configuration        January 2022
      |<--------------------------------------------------------------------------|
      | -------------------------------\         |         |          |           |
      |-| both DNR ADNs are authorized |         |         |          |           |
+     | ----------------------\--------|         |         |          |           |
+     |-| finished validation |                  |         |          |           |
 
 
 
-Reddy, et al.             Expires July 17, 2022                 [Page 7]
+Reddy, et al.             Expires July 18, 2022                 [Page 7]
 
 Internet-Draft       Split-Horizon DNS Configuration        January 2022
 
 
-     | ----------------------\--------|         |         |          |           |
-     |-| finished validation |                  |         |          |           |
      | |---------------------|                  |         |          |           |
      |                                          |         |          |           |
      |  use network-designated resolver         |         |          |           |
@@ -441,17 +439,16 @@ Internet-Draft       Split-Horizon DNS Configuration        January 2022
 
    This specification does not alter DNSSEC validation behavior.  To
    ensure compatibility with validating clients, network operators MUST
+   ensure that names under the split horizon are correctly signed or
+   place them in an unsigned zone.
 
 
 
 
-Reddy, et al.             Expires July 17, 2022                 [Page 8]
+Reddy, et al.             Expires July 18, 2022                 [Page 8]
 
 Internet-Draft       Split-Horizon DNS Configuration        January 2022
 
-
-   ensure that names under the split horizon are correctly signed or
-   place them in an unsigned zone.
 
 7.  IANA Considerations
 
@@ -496,19 +493,18 @@ Internet-Draft       Split-Horizon DNS Configuration        January 2022
               RFC 6761, DOI 10.17487/RFC6761, February 2013,
               <https://www.rfc-editor.org/info/rfc6761>.
 
-
-
-
-
-
-Reddy, et al.             Expires July 17, 2022                 [Page 9]
-
-Internet-Draft       Split-Horizon DNS Configuration        January 2022
-
-
    [RFC6762]  Cheshire, S. and M. Krochmal, "Multicast DNS", RFC 6762,
               DOI 10.17487/RFC6762, February 2013,
               <https://www.rfc-editor.org/info/rfc6762>.
+
+
+
+
+
+Reddy, et al.             Expires July 18, 2022                 [Page 9]
+
+Internet-Draft       Split-Horizon DNS Configuration        January 2022
+
 
    [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
               2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
@@ -554,18 +550,17 @@ Internet-Draft       Split-Horizon DNS Configuration        January 2022
               Practices", draft-krishnaswamy-dnsop-dnssec-split-view-04
               (work in progress), March 2007.
 
-
-
-
-Reddy, et al.             Expires July 17, 2022                [Page 10]
-
-Internet-Draft       Split-Horizon DNS Configuration        January 2022
-
-
    [INS]      The Unicode Consortium, "Vodafone Foundation Instant
               Schools for Sub-Saharan Africa",
               <https://www.vodafone.com/about/vodafone-foundation/focus-
               areas/instant-schools>.
+
+
+
+Reddy, et al.             Expires July 18, 2022                [Page 10]
+
+Internet-Draft       Split-Horizon DNS Configuration        January 2022
+
 
    [private-relay]
               CA/B Forum, "How Apple's iCloud Private Relay supports
@@ -609,19 +604,19 @@ Internet-Draft       Split-Horizon DNS Configuration        January 2022
               (ACME)", RFC 8555, DOI 10.17487/RFC8555, March 2019,
               <https://www.rfc-editor.org/info/rfc8555>.
 
-
-
-
-
-Reddy, et al.             Expires July 17, 2022                [Page 11]
-
-Internet-Draft       Split-Horizon DNS Configuration        January 2022
-
-
    [RFC8598]  Pauly, T. and P. Wouters, "Split DNS Configuration for the
               Internet Key Exchange Protocol Version 2 (IKEv2)",
               RFC 8598, DOI 10.17487/RFC8598, May 2019,
               <https://www.rfc-editor.org/info/rfc8598>.
+
+
+
+
+
+Reddy, et al.             Expires July 18, 2022                [Page 11]
+
+Internet-Draft       Split-Horizon DNS Configuration        January 2022
+
 
    [RFC8806]  Kumari, W. and P. Hoffman, "Running a Root Server Local to
               a Resolver", RFC 8806, DOI 10.17487/RFC8806, June 2020,
@@ -669,4 +664,9 @@ Authors' Addresses
 
 
 
-Reddy, et al.             Expires July 17, 2022                [Page 12]
+
+
+
+
+
+Reddy, et al.             Expires July 18, 2022                [Page 12]

--- a/draft-reddy-add-enterprise-split-dns-08.xml
+++ b/draft-reddy-add-enterprise-split-dns-08.xml
@@ -261,8 +261,8 @@
           of its choice (e.g. querying one of the network-provided resolvers,
           performing iterative resolution locally), and performs full DNSSEC
           validation locally <xref target="RFC6698"></xref>.  If the result
-          is "Unsigned Zone", clients SHOULD retry using the method in <xref
-          target="public"/>.</t>
+          is "Insecure" (Section 5 of <xref target="RFC4034"/>), clients SHOULD
+          retry using the method in <xref target="public"/>.</t>
         </section>
       </section>
     </section>
@@ -461,6 +461,8 @@
       <?rfc include='reference.RFC.8310'?>
 
       <?rfc include='reference.RFC.6698'?>
+
+      <?rfc include='reference.RFC.4034'?>
     </references>
 
     <references title="Informative References">

--- a/draft-reddy-add-enterprise-split-dns-08.xml
+++ b/draft-reddy-add-enterprise-split-dns-08.xml
@@ -190,13 +190,10 @@
         a nameserver claims a zone that does not exist in the global DNS.  This
         is a form of domain camping because it seizes a portion of the parent
         zone without permission.  The use of nonexistent TLDs for local
-        services is a form of NXDOMAIN camping on the root zone.
-        </t>
+        services is a form of NXDOMAIN camping on the root zone.</t>
 
-        <t>Domain camping can be used as an attack vector to impersonate a
-        targeted domain. Any form of domain camping likely violates
-        the IAB's guidance regarding "the Unique DNS Root"
-        <xref target="RFC2826"/>.</t>
+        <t>Any form of domain camping likely violates the IAB's guidance
+        regarding "the Unique DNS Root" <xref target="RFC2826"/>.</t>
       </section>
     </section>
 
@@ -241,11 +238,10 @@
         strategies are described in <xref target="public"/> and <xref
         target="dnssec"/>.</t>
 
-        <t>Note that this confirmation of authority applies only to the specific
-        resolvers whose ADNs appear in each RRSet. If a network offers multiple
-        encrypted resolvers via DNR, each dnsZone entry may be authorized for
-        a distinct subset of the resolvers. If TLS certificate validation
-        fails for the ADN, that resolver MUST NOT be considered authorized.</t>
+        <t>Note that each dnsZones entry is authorized only for the specific
+        resolvers whose ADNs appear in its NS RRSet. If a network offers
+        multiple encrypted resolvers via DNR, each dnsZones entry may be
+        authorized for a distinct subset of the network-provided resolvers.</t>
 
         <section anchor="public"
                  title="Confirmation using a pre-configured public resolver">
@@ -261,8 +257,9 @@
           of its choice (e.g. querying one of the network-provided resolvers,
           performing iterative resolution locally), and performs full DNSSEC
           validation locally <xref target="RFC6698"></xref>.  If the result
-          is "Insecure" (Section 5 of <xref target="RFC4034"/>), clients SHOULD
-          retry using the method in <xref target="public"/>.</t>
+          is "Insecure" (Section 5 of <xref target="RFC4034"/>), the client
+          SHOULD retry using a different method, such as the one in
+          <xref target="public"/>.</t>
         </section>
       </section>
     </section>

--- a/draft-reddy-add-enterprise-split-dns-08.xml
+++ b/draft-reddy-add-enterprise-split-dns-08.xml
@@ -98,48 +98,59 @@
     <workgroup>ADD</workgroup>
 
     <abstract>
-      <t>When split-horizon DNS is deployed by a network, certain domains are
-      only resolvable by querying the network-designated DNS server rather
-      than a public DNS server. DNS clients which use DNS servers not provided
-      by the network need to route those DNS domain queries to the
-      network-designated DNS server. This document informs DNS clients of
-      split-horizon DNS, their DNS domains, and is compatible with encrypted
-      DNS.</t>
+      <t>When split-horizon DNS is deployed by a network, certain domains can
+      be resolved authoritatively by the network-provided DNS resolver.
+      DNS clients that don't always use this resolver might wish to do so
+      for these domains. This specification enables networks to inform DNS
+      clients about domains that are inside the split horizon DNS, and
+      describes how clients can confirm the local resolver's authority over
+      these domains.</t>
     </abstract>
   </front>
 
   <middle>
     <section anchor="intro" title="Introduction">
-      <t>Historically, an endpoint would utilize network-designated DNS
-      servers upon joining a network (e.g., DHCP OFFER, IPv6 Router
-      Advertisement). While it has long been possible to configure endpoints
-      to ignore the network's suggestions and use a public DNS server on the
-      Internet, this was seldom used because some networks block UDP/53 in
-      order to enforce their own DNS policies. Also, there has been an
-      increase in the availability of "public resolvers" <xref
-      target="RFC8499"></xref> which DNS clients may be pre-configured to use
-      instead of the default network resolver for a variety of reasons (e.g.,
-      offer a good reachability, support an encrypted transport, provide a
-      claimed privacy policy, (lack of) filtering). With the advent of DoT and
-      DoH, the endpoint is unable to properly resolve split-horizon DNS
-      domains which must query the network-designated DNS server.</t>
+      <t>To resolve a DNS query, there are three essential behaviors that an
+      implementation can apply: (1) answer from a local database, (2) query
+      the relevant authorities and their parents, or (3) ask a server to query
+      those authorities and return the final answer. Implementations that use
+      these behaviors are called "authoritative nameservers", "full resolvers",
+      and "forwarders" (or "stub resolvers"). However, an implementation can
+      also implement a mixture of these behaviors, depending on a local policy,
+      for each query.  We term such an implementation a "hybrid resolver".</t>
 
-      <t>This document specifies a mechanism to indicate which DNS zones are
-      used for split-horizon DNS. DNS clients can discover and authenticate
-      DNS servers provided by the network, for example using the techniques
-      proposed in <xref target="I-D.ietf-add-dnr"></xref> and <xref
-      target="I-D.ietf-add-ddr"></xref>.</t>
+      <t>Most DNS resolvers are hybrids of some kind. For example, stub
+      resolvers frequently support a local "hosts file" that preempts query
+      forwarding, and most DNS forwarders and full resolvers can also serve
+      responses from a local zone file.  Other standardized hybrid resolution
+      behaviors include Local Root <xref target="RFC8806"/>, mDNS <xref
+      target="RFC6762"/>, and NXDOMAIN synthesis for .onion <xref
+      target="RFC7686"/>.</t>
 
-      <t>The scope of the specification is full split-horizon (<xref
-      target="full"></xref>) DNS names, which are not domains reserved for
-      special use like ".local". Using these domains are difficult because
-      bookmarks, advertising, and human behavior would need to change so that
-      the special domains only work when connected to the correct network,
-      which is difficult for users to discern on most endpoints. Furthermore,
-      as special domains cannot obtain certificates from a public CA,
-      authenticated TLS connections to those servers are fraught with (Trust
-      on First Use) and certificate warnings, a longstanding problem in the
-      industry.</t>
+      <t>In many network environments, the network offers clients a DNS server
+      (e.g. in DHCP OFFER, IPv6 Router Advertisement). Although this server is
+      formally specified as a recursive resolver (e.g. Section 5.1 of
+      <xref target="RFC6106"/>), some networks provide a hybrid resolver instead.
+      If this resolver acts as an authoritative server for some names,
+      we say that the network has "split horizon DNS", because those names
+      resolve in this way only from inside the network.</t>
+
+      <t>Network clients that use pure stub resolution, sending all queries to
+      the network-provided resolver, will always receive the split-horizon
+      results. Conversely, clients that send all queries to a different
+      resolver or implement pure full resolution locally will never receive them.
+      Clients with either pure resolution behavior are out of scope for this
+      specification. Instead, this specification enables hybrid clients to
+      access split-horizon results from a network-provided hybrid resolver,
+      while using a different resolution method for some or all other names.</t>
+
+      <t>To achieve the required security properties, clients must be able to
+      authenticate the DNS servers provided by the network, for example using
+      the techniques proposed in <xref target="I-D.ietf-add-dnr"></xref> and <xref
+      target="I-D.ietf-add-ddr"></xref>, and prove that they are authorized to
+      serve the offered split-horizon names. As a result, use of this
+      specification is limited to servers that support authenticated encryption
+      and split-horizon names that are properly rooted in the global DNS.</t>
     </section>
 
     <section anchor="notation" title="Terminology">
@@ -156,82 +167,14 @@
       <t>'Encrypted DNS' refers to a DNS protocol that provides an encrypted
       channel between a DNS client and server (e.g., DoT, DoH, or DoQ).</t>
 
-      <t>Two new terms, Full Split Horizon and Lame Delegation Split Horizon,
-      are defined as summarized in the following table. <figure>
-          <artwork><![CDATA[+--------------------+----------------------+--------------------------+
-+ split horizon type +   query on Internet  | query on private network |
-+--------------------+----------------------+--------------------------+
-+ full               +  IP address <public> |   IP address <private>   |
-+--------------------+----------------------+--------------------------+
-+ lame delegation    +     no such host     |   IP address <private>   |
-+--------------------+----------------------+--------------------------+]]></artwork>
-        </figure></t>
+      <t>The terms 'Authorized Split Horizon' and 'Domain Camping' are also
+      defined.</t>
 
-      <t>The term 'Domain Camping' is also defined.</t>
-
-      <section anchor="full" title="Full Split Horizon">
-        <t>Full Split Horizon refers to a delegation on both the
-        Internet-facing DNS server and the internal-facing DNS server, where
-        an A or AAAA query results in a different answer.</t>
-
-        <t>Example: When issued an "A" query for www.example.com, the
-        Internet-facing DNS server answers with 203.0.113.1 and
-        internal-facing DNS server answers with 192.0.2.1.</t>
-
-        <t>Benefits: <list style="symbols">
-            <t>URLs resolve equally well on both public and internal networks,
-            but to different IP addresses, as desired by the DNS
-            administrator.</t>
-          </list></t>
-
-        <t>Complications: <list style="symbols">
-            <t>Can cause cache confusion.</t>
-
-            <t>Clients need to query the appropriate DNS server to get the
-            appropriate answer.</t>
-          </list></t>
-      </section>
-
-      <section title="Lame Delegation Split Horizon">
-        <t>Lame Delegation Split Horizon (or "lame split") refers to a lame
-        delegation on the Internet but a proper delegation on the internal
-        servers.</t>
-
-        <t>Example: On the public Internet, the zone internal.example.com is
-        not delegated at all, or alternatively, the delegation is purposefully
-        defective (e.g., NS record points to non-existent or non-responding
-        nameserver). On the private network, that same zone
-        internal.example.com exists and FQDNs within it are resolvable, such
-        as www.internal.example.com which resolves to 192.0.2.2.</t>
-
-        <t><list>
-            <t>Note: Lame Delegation Split Horizon is not in scope for this
-            document. It is only documented for completeness. Implementations
-            like iCloud Private Relay detect that the domain being used is not
-            a public Internet name and instructs the device to access the
-            domain directly over the local network <xref
-            target="private-relay"></xref>.</t>
-          </list></t>
-
-        <t>Benefits: <list style="symbols">
-            <t>If the client receives an error when querying the public
-            server, it can query the internal server. While this exposes
-            internal host names to the public server, this eases client
-            configuration burden and can improve overall user
-            satisfaction.</t>
-          </list></t>
-
-        <t>Complications: <list style="symbols">
-            <t>In cases where the internal DNS server cannot be queried, URLs
-            referencing host names only resolvable by the internal DNS server
-            will not be resolvable and cause application errors. These errors
-            can confuse users who see they are connected to the network, yet
-            cannot resolve a host name.</t>
-
-            <t>CA-signed certificates cannot be obtained for names that are
-            not resolvable on the Internet <xref
-            target="cabforum"></xref>.</t>
-          </list></t>
+      <section title="Authorized Split Horizon">
+        <t>A split horizon configuration for some name is considered "authorized"
+        if any parent of that name has given the local network permission to
+        serve its own responses for that name. Such authorizations generally
+        extend to the entire subtree of names below the authorization point.</t>
       </section>
 
       <section title="Domain Camping">
@@ -242,64 +185,36 @@
         example.com on the Internet. Someone might domain camp on a popular
         domain name providing the ability to monitor queries and modify
         answers for that domain.</t>
+
+        <t>A common variation on domain camping is "NXDOMAIN camping", in which
+        a nameserver claims a zone that does not exist in the global DNS.  This
+        is a form of domain camping because it seizes a portion of the parent
+        zone without permission.  The use of nonexistent TLDs for local
+        services is a form of NXDOMAIN camping on the root zone.
+        </t>
+
+        <t>Domain camping can be used as an attack vector to impersonate a
+        targeted domain. Any form of domain camping likely violates
+        the IAB's guidance regarding "the Unique DNS Root"
+        <xref target="RFC2826"/>.</t>
       </section>
     </section>
 
-    <section anchor="split-horizon" title="Overview for Full Split Horizon">
-      <t>There are various DNS deployments outside of the global DNS,
-      including "split horizon" deployments and DNS usages on private (or
-      virtual private) networks. In a Full Split Horizon, an authoritative
-      server gives different responses to queries from the Internet than they
-      do to network-designated DNS servers; while some deployments
-      differentiate internal queries from public queries by the source IP
-      address, the concerns in Section 3.1.1 of <xref target="RFC6950"></xref>
-      relating to trusting source IP addresses apply to such deployments.</t>
-
-      <t>When the internal address space range is private <xref
-      target="RFC1918"></xref>, this makes it both easier for the server to
-      discriminate public from private and harder for public entities to
-      impersonate nodes in the private network. The use cases that motivate
-      Full Split Horizon DNS typically involves restricting access to internal
-      services to the devices attached and authenticated to the network.</t>
-
-      <t>A typical use case is an Enterprise network that requires one or more
-      DNS domains to be resolved via network-designated DNS servers. An
-      Enterprise can run a different version of its global domain on its
-      internal network. In that case, the client is instructed to send DNS
-      queries for the enterprise public domain (e.g., "example.com") to the
-      network-designated DNS servers. A configuration for this deployment
-      scenario is referred to as a Full Split Horizon DNS configuration.
-      Another use case for Full Split Horizon DNS is Cellular and Fixed-access
-      networks (ISPs) typically offer value-added subscriber services,
-      including account status/controls, and free education initiatives <xref
-      target="INS"></xref>.</t>
-    </section>
-
     <section anchor="dnsZones" title="Provisioning Domains dnsZones">
-      <t>As discussed in <xref target="split-horizon"></xref>, a network can
-      run a different version of its global domain on its internal network,
-      and require the use of network-designated DNS servers to get
-      resolved.</t>
-
       <t>Provisioning Domains (PvDs) are defined in <xref
       target="RFC7556"></xref> as sets of network configuration information
       that clients can use to access networks, including rules for DNS
       resolution and proxy configuration. The PvD Key dnsZones is defined in
-      <xref target="RFC8801"></xref>. The PvD Key dnsZones adds support for
-      DNS domains for which the network claims authority, and which are
-      intended to be resolved using network-designated DNS servers. The global
-      domains specified in the dnsZones key have a different version in the
-      internal network. DNS resolution for other domains remains
-      unchanged.</t>
+      <xref target="RFC8801"></xref>. The PvD Key dnsZones notifies clients
+      of names for which one of the network-provided resolvers is authoritative.
+      Attempting to resolve these names via another resolver might fail or
+      return results that are not correct for this network.</t>
 
-      <t>For each dnsZones entry, the client can use the network-designated
-      DNS servers to resolve the listed domains and its subdomains. Other
-      domain names may be resolved using some other DNS servers that are
-      configured independently. For example, if the dnsZones key specifies
-      "example.test", then "example.test", "www.example.test", and
-      "mail.eng.example.test" can be resolved using the network-designated DNS
-      resolver(s), but "otherexample.test" and "ple.test" can be resolved
-      using the system's public resolver(s).</t>
+      <t>Each dnsZones entry indicates a claim of authority over a domain
+      and its subdomains. For example, if the dnsZones entry is
+      "example.test", this covers "example.test", "www.example.test", and
+      "mail.eng.example.test", but not "otherexample.test" or
+      "example.test.net".</t>
 
       <t><xref target="RFC8801"></xref> defines a mechanism for discovering
       multiple Explicit PvDs on a single network and their Additional
@@ -311,209 +226,49 @@
       object SHOULD include the "dnsZones" key to define the DNS domains for
       which the network claims authority.</t>
 
-      <section anchor="Authority" title="Authority over the Domains">
-        <t>To comply with <xref target="RFC2826"></xref> the split-horizon DNS
-        zone must either not exist in the global DNS hierarchy or must be
-        authoritatively delegated to the split-horizon DNS server to answer.
-        The DNS root zone (".") MUST be ignored if it appears in dnsZones.
-        Other generic or global domains, such as Top-Level Domains (TLDs),
-        similarly MUST be ignored if they appear in dnsZones.</t>
+      <section anchor="Authority" title="Confirming Authority over the Domains">
+        <t>To comply with <xref target="RFC2826"></xref>, each dnsZones entry
+        must be authorized in the global DNS hierarchy. To prevent domain
+        camping, clients SHOULD confirm this authorization before making use of
+        the entry.</t>
+        
+        <t>To enable confirmation, the client MUST discover and validate the Authentication Domain Names (ADNs) of the network-designated resolvers
+        using a method such as DNR <xref target="I-D.ietf-add-dnr"/>. The
+        client MUST also perform an NS query for each dnsZones entry and
+        confirm that at least one of the ADNs appears in each NS RRSet.  This
+        NS query SHOULD be conducted in a manner that is not vulnerable to
+        tampering by the local network. Suitable tamperproof resolution
+        strategies are described in <xref target="public"/> and <xref
+        target="dnssec"/>.</t>
 
-        <t>The client can use the mechanism described in <xref
-        target="I-D.ietf-add-dnr"></xref> to discover the network-designated
-        resolvers. To determine if the network-designated encrypted resolvers
-        are authoritative over the domains in dnsZones, the client can use any
-        one of the mechanisms discussed in <xref target="public"></xref>,
-        <xref target="dnssec"></xref> and <xref target="cert"></xref>.</t>
+        <t>Note that this confirmation of authority applies only to the specific
+        resolvers whose ADNs appear in each RRSet. If a network offers multiple
+        encrypted resolvers via DNR, each dnsZone entry may be authorized for
+        a distinct subset of the resolvers. If TLS certificate validation
+        fails for the ADN, that resolver MUST NOT be considered authorized.</t>
 
         <section anchor="public"
-                 title="Authority based on a pre-configured public resolver">
-          <t>The client uses the following steps for each domain in
-          dnsZones:</t>
-
-          <t><list style="numbers">
-              <t>The client sends an NS query for the domain in dnsZones. This
-              query must only be sent over encrypted DNS session to a public
-              resolver that is configured independently. A DNSSEC-validating
-              client SHOULD apply the same validation policy to the NS query
-              as it does to other queries. A client that does not validate
-              DNSSEC SHOULD apply the same policy (if any) to the NS query as
-              it does to other queries. It is the choice of a client to either
-              perform full DNSSEC validation of answers or to trust the public
-              resolver to do DNSSEC validation and inspect the AD (Authentic
-              Data) bit in the returned message to determine whether an answer
-              is authentic or not.</t>
-
-              <t>The client checks that the NS RRset matches any one of the
-              Authentication Domain Names (ADNs) of the discovered
-              network-designated encrypted DNS resolvers. <list
-                  style="letters">
-                  <t>If the match fails and no ADN of the discovered
-                  network-designated encrypted DNS resolvers is a subdomain of
-                  NS RRset, the client determines the network is not
-                  authoritative for the indicated domain. It might log an
-                  error, reject the network entirely (because the network lied
-                  about its authority over a domain) or other action.</t>
-
-                  <t>If the match fails but any one of the ADNs of the
-                  discovered network-designated encrypted DNS resolvers is a
-                  subdomain of NS RRset, the client can then establish a TLS
-                  connection to that network-designated resolver. The client
-                  follows the mechanism discussed in Section 8 of <xref
-                  target="RFC8310"></xref> to authenticate the DNS server
-                  certificate using the ADN and checks if at least one of the
-                  values in subjectAltName matches NS RRset. If the server
-                  certificate validation and match succeeds, the client can
-                  subsequently resolve the domains in that subtree using the
-                  network-designated resolver. If the server certificate does
-                  not validate or match fails, the client can proceed as
-                  discussed in step 2 (A).</t>
-
-                  <t>If the match succeeds, the client can then establish a
-                  TLS connection to that network-designated resolver. The
-                  client follows the mechanism discussed in Section 8 of <xref
-                  target="RFC8310"></xref> to authenticate the DNS server
-                  certificate using the ADN.<list style="symbols">
-                      <t>If the server certificate does not validate and a
-                      secure connection cannot be established to the network
-                      designated resolver, the client can proceed as discussed
-                      in step 2 (A).</t>
-
-                      <t>If the server certificate validation is successful
-                      and a secure connection is established, the client can
-                      subsequently resolve the domains in that subtree using
-                      the network-designated resolver.</t>
-                    </list></t>
-                </list></t>
-            </list></t>
-
-          <t>The mechanism has the following list of advantages in no
-          particular order:</t>
-
-          <t><list style="symbols">
-              <t>As of the time of writing this specification OS and Browsers
-              have multiple pre-configured public resolvers and any one of the
-              pre-configured public resolver can be used.</t>
-            </list></t>
-
-          <t>The mechanism has the following list of caveats in no particular
-          order:</t>
-
-          <t><list style="symbols">
-              <t>If the attached network blocks access to the public resolver,
-              the client will have to either use a different network or use
-              the network-designated resolver to resolve all domains.</t>
-            </list></t>
+                 title="Confirmation using a pre-configured public resolver">
+          <t>The client sends an NS query for the domain in dnsZones to a
+          pre-configured resolver that is external to the network, over a
+          secure transport. Clients SHOULD apply whatever acceptance rules
+          they would otherwise apply when using this resolver (e.g. checking
+          the AD bit, revalidating DNSSEC).</t>
         </section>
 
-        <section anchor="dnssec" title="DNSSEC verification">
-          <t>The proposed mechanism below requires a DNSSEC-validating stub
-          implementation (Section 2 of <xref target="RFC4033"></xref>). The
-          client can either send the queries in recursive or iterative mode
-          but performs signature validation on its own. Note that <xref
-          target="RFC7901"></xref> defines an EDNS0 extension that allows a
-          validating stub implementation to send a single query, requesting a
-          complete validation path along with the regular query answer. The
-          reduction in DNSSEC queries potentially lowers the latency and
-          reduces the need to send multiple queries at once.</t>
-
-          <t>Clients that validate the DNSSEC signatures can perform the
-          following steps for each domain in dnsZones:</t>
-
-          <t><list style="numbers">
-              <t>The client sends an NS query for the domain in dnsZones. This
-              query is sent to the network-designated resolvers. The response
-              records MUST be validated using DNSSEC as described in <xref
-              target="RFC6698"></xref>.</t>
-
-              <t>The client checks that the NS RRset matches any one of the
-              Authentication Domain Names (ADNs) of the discovered
-              network-designated encrypted DNS resolvers. <list
-                  style="letters">
-                  <t>If the match fails, the client determines the network is
-                  not authoritative for the indicated domain. It might log an
-                  error, reject the network entirely (because the network lied
-                  about its authority over a domain) or other action.</t>
-
-                  <t>If the match succeeds, the client can then establish a
-                  TLS connection to that network-designated resolver. The
-                  client follows the mechanism discussed in Section 8 of <xref
-                  target="RFC8310"></xref> to authenticate the DNS server
-                  certificate using the ADN.<list style="symbols">
-                      <t>If the server certificate does not validate and a
-                      secure connection cannot be established to the network
-                      designated resolver, the client can proceed as discussed
-                      in step 2 (A).</t>
-
-                      <t>If the server certificate validation is successful
-                      and a secure connection is established, the client can
-                      subsequently resolve the domains in that subtree using
-                      the network-designated resolver.</t>
-                    </list></t>
-                </list></t>
-            </list></t>
-
-          <t>The mechanism has the following list of advantages in no
-          particular order:</t>
-
-          <t><list style="symbols">
-              <t>This approach does not require the client to access a public
-              resolver to prove the authority over the domains.</t>
-            </list></t>
-
-          <t>The mechanism has the following list of caveats in no particular
-          order:</t>
-
-          <t><list style="symbols">
-              <t>The deployment of DNSSEC-validating stub implementation is
-              limited at the time of this writing specification.</t>
-            </list></t>
-        </section>
-
-        <section anchor="cert" title="Certificate verification">
-          <t>The client uses the mechanism described in <xref
-          target="I-D.ietf-add-dnr"></xref> to discover the ADNs of the
-          network-designated resolvers. The client performs the following
-          steps for each of the ADN:</t>
-
-          <t><list style="numbers">
-              <t>The client establishes a TLS connection to the ADN. The
-              client follows the mechanism discussed in Section 8 of <xref
-              target="RFC8310"></xref> to authenticate the DNS server
-              certificate using the ADN. If the server certificate does not
-              validate, it might log an error, reject the network entirely or
-              other action.</t>
-
-              <t>If the server certificate validation succeeds, the client
-              checks if the domains in dnsZones match the values in the
-              subjectAltName. If the match succeeds, the client can
-              subsequently resolve the matched domains in that subtree using
-              the network-designated resolver.</t>
-            </list></t>
-
-          <t>The mechanism has the following list of advantages in no
-          particular order:</t>
-
-          <t><list style="symbols">
-              <t>It does not require the client to access a public resolver or
-              requires the use of DNSSEC-validating stub implementation to
-              prove the authority over the domains. </t>
-            </list></t>
-
-          <t>The mechanism has the following list of caveats in no particular
-          order:</t>
-
-          <t><list style="symbols">
-              <t>It requires the use of certificates with multiple dNSName
-              identifiers which are supported by both CAs and ACME protocol <xref
-              target="RFC8555"></xref>.</t>
-            </list></t>
+        <section anchor="dnssec" title="Confirmation using DNSSEC">
+          <t>The client resolves the NS record using any resolution method
+          of its choice (e.g. querying one of the network-provided resolvers,
+          performing iterative resolution locally), and performs full DNSSEC
+          validation locally <xref target="RFC6698"></xref>.  If the result
+          is "Unsigned Zone", clients SHOULD retry using the method in <xref
+          target="public"/>.</t>
         </section>
       </section>
     </section>
 
     <section title="An example of Split-Horizon DNS Configuration">
-      <t>In a network the apex domain name is "example.com", which runs a
+      <t>Consider an organization that operates "example.com", and runs a
       different version of its global domain on its internal network. Today,
       on the Internet it publishes two NS records, "ns1.example.com" and
       "ns2.example.com".</t>
@@ -521,50 +276,32 @@
       <t>To add support for the mechanism described in this document, the
       network and endpoints first need to support <xref
       target="I-D.ietf-add-dnr"></xref> and <xref target="RFC8801"></xref>.
-      Then, for each site the administrator would add DNS server names which
-      end in "ns1.example.com" or "ns2.example.com" (the names published on
-      the Internet). Also on its internal network, it uses a geographic naming
-      scheme for its internal nameservers with a "service dot location" naming
-      scheme. Assuming its two geographies are "us" and "uk". So the UK site
-      would add "ns1.uk.ns1.example.com" and "ns2.uk.ns2.example.com". Note
-      that these names can be added in addition to more traditional names that
-      might already exist for those DNS servers (e.g., the common "service dot
-      location" such as "ns1.uk.example.com"). All of those names would be
-      advertised to the endpoints as described in <xref
-      target="I-D.ietf-add-dnr"></xref>.</t>
+      Then, for each site, the administrator would add DNS servers named
+      "ns1.example.com" or "ns2.example.com" (the names published on
+      the Internet). Those names would be advertised to the endpoints as
+      described in <xref target="I-D.ietf-add-dnr"></xref>.</t>
 
       <t>The endpoints compliant with this specification can then determine
       the network's internal nameservers are owned and managed by the same
-      entity that has published the NS records on the Internet, as described
-      in the following paragraphs:</t>
-
-      <t>Continuing with the UK site as the example, the endpoint will join
-      the network, obtain an IPv6 address, and using <xref
-      target="I-D.ietf-add-dnr"></xref> will discover the resolvers
-      "ns1.uk.ns1.example.com" and "ns2.uk.ns2.example.com" and their IP
-      addresses. Using <xref target="RFC8801"></xref> (which utilizes IPv6
-      Router Advertisments), the endpoint will also discover the PvD FQDN is
-      "pvd.uk.example.com".</t>
-
-      <t>Continuing with the UK site as the example, the endpoint performs the
-      following steps corresponding with the call flow diagram numbers:</t>
+      entity that has published the NS records on the Internet as shown in
+      <xref target="poex"/>:</t>
 
       <t><list style="hanging">
-          <t hangText="Steps 1-2:">The client joins the network, obtain an IP
-          address, and using <xref target="I-D.ietf-add-dnr"></xref> will
-          discover the resolvers "ns1.uk.ns1.example.com" and
-          "ns2.uk.ns1.example.com" and their IP addresses. Using <xref
-          target="RFC8801"></xref>, the endpoint will also discover the PvD
-          FQDN is "pvd.uk.example.com".</t>
+          <t hangText="Steps 1-2:">The client joins the network, obtains an IP
+          address, and discovers the resolvers "ns1.example.com" and
+          "ns2.example.com" and their IP addresses using DNR
+          <xref target="I-D.ietf-add-dnr"></xref>. Using <xref
+          target="RFC8801"></xref>, the client also discovers the PvD
+          FQDN is "pvd.example.com".</t>
 
           <t hangText="Steps 3-7:">The client establishes an encrypted DNS
-          connection with "ns1.uk.ns1.example.com", validates its TLS
-          certificate, and queries it for "pvd.uk.example.com" to retrieve the
+          connection with "ns1.example.com", validates its TLS
+          certificate, and queries it for "pvd.example.com" to retrieve the
           PvD JSON object. Note that <xref target="RFC8801"></xref> in Section
           4.1 mandates the PvD FQDN MUST be resolved using the DNS servers
           indicated by the associated PvD. The PvD contains:<figure>
               <artwork><![CDATA[ {
-    "identifier": "pvd.uk.example.com",   
+    "identifier": "pvd.example.com",   
     "expires": "2020-05-23T06:00:00Z",
     "prefixes": ["2001:db8:1::/48", "2001:db8:4::/48"],
     "dnsZones:": ["example.com"]
@@ -578,7 +315,7 @@
           return "ns1.example.com" and "ns2.example.com".</t>
 
           <t hangText="Step 10:">As the network-provided nameservers are
-          subdomains of those names retrieved from the public resolver and the
+          the same as the names retrieved from the public resolver and the
           network-designated resolver's certificate includes at least one of
           the names retrieved from the public resolver, the client has
           finished validation that the nameservers signaled in <xref
@@ -589,68 +326,64 @@
           target="RFC8801"></xref> to resolve names within dnsZones.</t>
         </list></t>
 
-      <t><xref target="poex"></xref> is a simple call flow diagram of the
-      example discussed above.</t>
-
       <figure anchor="poex"
               title="An Example of Split-Horizon DNS Configuration">
-        <artwork><![CDATA[+---------+                    +---------------------+  +------------+ +---------+ +---------+
-| client  |                    | Network             |  | Network    | | Router  | | public  |
-|         |                    | encrypted resolvr   |  | PvD server | |         | | resolvr |
-+---------+                    +---------------------+  +------------+ +---------+ +---------+
-     |                                             |         |          |           |
-     | Router Solicitation (1)                     |         |          |           |
-     |----------------------------------------------------------------->|           |
-     |                                             |         |          |           |
-     |       Router Advertisement with DNR hostnames & PvD FQDN (2)     |           |
-     |<----------------------------------=------------------------------|           |
-     | -------------------------------------\      |         |          |           |
-     |-| now knows DNR hostnames & PvD FQDN |      |         |          |           |
-     | |------------------------------------|      |         |          |           |
-     |                                             |         |          |           |
-     | TLS connection to ns1.uk.ns1.example.com (3)|         |          |           |      
-     |----------------------------------------- -->|         |          |           |
-     | ---------------------------\                |         |          |           |
-     |-| validate TLS certificate |                |         |          |           |
-     | |--------------------------|                |         |          |           |
-     |                                             |         |          |           |
-     | resolve pvd.uk.example.com  (4)             |         |          |           |
-     |-------------------------------------------->|         |          |           |
-     |                                             |         |          |           |
-     |                         AAAA records (5)    |         |          |           |
-     |<--------------------------------------------|         |          |           |
-     |                                             |         |          |           |
-     | https://pvd.uk.example.com/.well-known/pvd (6)        |          |           |
-     |------------------------------------------------------>|          |           |
-     |                                             |         |          |           |
-     |       200 OK (JSON Additional Information) (7)        |          |           |
-     |<------------------------------------------------------|          |           |
-     | -----------------------\                    |         |          |           |
-     |-| dnsZones=example.com |                    |         |          |           |
-     | |----------------------|                    |         |          |           |
-     |                                             |         |          |           |
-     | TLS connection                              |         |          |           |
-     |----------------------------------------------------------------------------->|
-     | ---------------------------\                |         |          |           |
-     |-| validate TLS certificate |                |         |          |           |
-     | |--------------------------|                |         |          |           |
-     |                                             |         |          |           |
-     | NS? example.com  (8)                        |         |          |           |
-     |----------------------------------------------------------------------------->|
-     |                                             |         |          |           |
-     |                               NS=ns1.example.com, ns2.example.com (9)        | 
-     |<-----------------------------------------------------------------------------|
-     | -------------------------------\            |         |          |           |
-     |-| ns1.uk.ns1.example.com is    |            |         |          |           |
-     | | subdomain of ns1.example.com |            |         |          |           |
-     | ----------------------\--------|            |         |          |           |
-     |-| finished validation |                     |         |          |           |
-     | |---------------------|                     |         |          |           |
-     |                                             |         |          |           |
-     |  use network-designated resolver            |         |          |           |   
-     |  for example.com (10)                       |         |          |           |
-     |-------------------------------------------->|         |          |           |
-     |                                             |         |          |           |
+        <artwork><![CDATA[+---------+                 +---------------------+  +------------+ +---------+ +---------+
+| client  |                 | Network             |  | Network    | | Router  | | public  |
+|         |                 | encrypted resolvr   |  | PvD server | |         | | resolvr |
++---------+                 +---------------------+  +------------+ +---------+ +---------+
+     |                                          |         |          |           |
+     | Router Solicitation (1)                  |         |          |           |
+     |-------------------------------------------------------------->|           |
+     |                                          |         |          |           |
+     |     Router Advertisement with DNR hostnames & PvD FQDN (2)    |           |
+     |<--------------------------------------------------------------|           |
+     | -------------------------------------\   |         |          |           |
+     |-| now knows DNR hostnames & PvD FQDN |   |         |          |           |
+     | |------------------------------------|   |         |          |           |
+     |                                          |         |          |           |
+     | TLS connection to ns1.example.com (3)    |         |          |           |      
+     |----------------------------------------->|         |          |           |
+     | ---------------------------\             |         |          |           |
+     |-| validate TLS certificate |             |         |          |           |
+     | |--------------------------|             |         |          |           |
+     |                                          |         |          |           |
+     | resolve pvd.example.com  (4)             |         |          |           |
+     |----------------------------------------->|         |          |           |
+     |                                          |         |          |           |
+     |                      AAAA records (5)    |         |          |           |
+     |<-----------------------------------------|         |          |           |
+     |                                          |         |          |           |
+     | https://pvd.example.com/.well-known/pvd (6)        |          |           |
+     |--------------------------------------------------->|          |           |
+     |                                          |         |          |           |
+     |      200 OK (JSON Additional Information) (7)      |          |           |
+     |<---------------------------------------------------|          |           |
+     | -----------------------\                 |         |          |           |
+     |-| dnsZones=example.com |                 |         |          |           |
+     | |----------------------|                 |         |          |           |
+     |                                          |         |          |           |
+     | TLS connection                           |         |          |           |
+     |-------------------------------------------------------------------------->|
+     | ---------------------------\             |         |          |           |
+     |-| validate TLS certificate |             |         |          |           |
+     | |--------------------------|             |         |          |           |
+     |                                          |         |          |           |
+     | NS? example.com  (8)                     |         |          |           |
+     |-------------------------------------------------------------------------->|
+     |                                          |         |          |           |
+     |                            NS=ns1.example.com, ns2.example.com (9)        | 
+     |<--------------------------------------------------------------------------|
+     | -------------------------------\         |         |          |           |
+     |-| both DNR ADNs are authorized |         |         |          |           |
+     | ----------------------\--------|         |         |          |           |
+     |-| finished validation |                  |         |          |           |
+     | |---------------------|                  |         |          |           |
+     |                                          |         |          |           |
+     |  use network-designated resolver         |         |          |           |   
+     |  for example.com (10)                    |         |          |           |
+     |----------------------------------------->|         |          |           |
+     |                                          |         |          |           |
 ]]></artwork>
       </figure>
     </section>
@@ -659,7 +392,7 @@
       <t>The split-tunnel Virtual Private Network (VPN) configuration allows
       the endpoint to access resources that reside in the VPN <xref
       target="RFC8598"></xref> via the tunnel; other traffic not destined to
-      the VPN does not traverse the tunnel. In contrast, a non-split- tunnel
+      the VPN does not traverse the tunnel. In contrast, a non-split-tunnel
       VPN configuration causes all traffic to traverse the tunnel into the
       VPN.</t>
 
@@ -674,7 +407,7 @@
       private domain names. For split-tunnel VPN configurations, the IKE
       client can use any one of the mechanisms discussed in <xref
       target="Authority"></xref> to determine if the VPN service provider is
-      authoritative over the Full Split Horizon DNS domains.</t>
+      authoritative over the Split Horizon DNS domains.</t>
 
       <t>Other VPN tunnel types have similar configuration capabilities, not
       detailed here.</t>
@@ -686,21 +419,17 @@
       untrusted and handled accordingly. The client must perform the
       mechanisms discussed in <xref target="Authority"></xref> to determine if
       the network-designated encrypted resolvers are authoritative over the
-      domains in dnsZones. If not, the client can take appropriate action like
-      disconnecting from the network.</t>
-
-      <t>In order to deploy DNSSEC operationally for split-horizon domains,
-      the first three schemes described in <xref
-      target="I-D.krishnaswamy-dnsop-dnssec-split-view"></xref> can be used
-      but not the one discussed in Section 4.1.4. Alternatively, after
-      validating the network authority over the dnsZones domains <xref
-      target="Authority"></xref>, a DNSSEC-validating client can reconfigure
-      its stub resolver to disable DNSSEC validation for the domains in
+      domains in dnsZones. If they are not, the client SHOULD ignore those
       dnsZones.</t>
+
+      <t>This specification does not alter DNSSEC validation behavior. To
+      ensure compatibility with validating clients, network operators MUST
+      ensure that names under the split horizon are correctly signed or
+      place them in an unsigned zone.</t>
     </section>
 
     <section anchor="IANA" title="IANA Considerations">
-      <t>This document has no IANA actions..</t>
+      <t>This document has no IANA actions.</t>
     </section>
 
     <section title="Acknowledgements">
@@ -748,6 +477,12 @@
       <?rfc include='reference.RFC.7556' ?>
 
       <?rfc include='reference.RFC.8555' ?>
+
+      <?rfc include='reference.RFC.7686' ?>
+
+      <?rfc include='reference.RFC.8806' ?>
+
+      <?rfc include='reference.RFC.6106' ?>
 
       <?rfc include='reference.I-D.ietf-add-dnr'?>
 


### PR DESCRIPTION
This change introduces a variety of revisions to the draft.
Editorially, the draft has been shortened to avoid any unnecessary
discussion of controversial topics and focus on concise description of
the technical elements.  Substantively, there are two changes:

1. Direct validation of ownership of the entry name has been removed.
   This validation mode is not secure, because control over the apex
   domain is not sufficient to prove authorization for the DNS contents
   of the zone.  For example, a website might give a CDN a certificate
   that covers their apex domain, but not wish to authorize the CDN to
   impersonate all of their subdomains.
2. The ".uk" ADN subdomains have been removed from the example.
   This arrangement is not allowed under the draft's own validation rules.